### PR TITLE
Fix TV mode layout overflow and update ticket/project views

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,19 @@
   const cssVar = (v) => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
 
   let CURRENT_USER = 'admin';
+  const TICKET_FIELD_LABELS = {
+    id:'ID',
+    createdAt:'Data de criação',
+    solicitante:'Aberto por',
+    telefone:'Contato',
+    meetPoint:'Ponto de encontro',
+    dupla:'Dupla',
+    concl:'% de conclusão',
+    prazo:'% de prazo',
+    resumo:'Resumo',
+    descricao:'Descrição'
+  };
+  const TICKET_FIELDS = Object.keys(TICKET_FIELD_LABELS);
 
   // ========== MOCK DE DADOS (carregado de db.json) =========
   function genHistory(finalPct){
@@ -124,8 +137,6 @@
                 <strong id="tdTitle">Chamado</strong>
                 <div style="display:flex; gap:6px; align-items:center">
                   <span class="badge" id="tdPct">0%</span>
-                  <button class="edit-btn" id="tdEdit">Editar</button>
-                  <button class="del-btn" id="tdDel">Excluir</button>
                 </div>
               </header>
               <div id="tdMeta" style="display:flex; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px"></div>
@@ -135,6 +146,7 @@
                 <button class="subtab" data-tab="tdNotes" style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Anotações</button>
                 <button class="subtab" data-tab="tdRDO"   style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">RDO's</button>
                 <button class="subtab" data-tab="tdObs"   style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Observações</button>
+                <button class="subtab" data-tab="tdEditForm" style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Editar</button>
               </div>
               <div class="subtab-panel active" id="tdDesc" style="padding-top:10px"></div>
               <div class="subtab-panel" id="tdNotes" style="display:none;padding-top:10px">
@@ -146,6 +158,7 @@
               <div class="subtab-panel" id="tdObs" style="display:none;padding-top:10px">
                 <textarea style="width:100%; min-height:120px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Observações gerais..."></textarea>
               </div>
+              <div class="subtab-panel" id="tdEditForm" style="display:none;padding-top:10px"></div>
             </div>
           </section>
 
@@ -262,6 +275,8 @@
     if (!els.ticketDetail) return;
     if (els.tdDesc) els.tdDesc.innerHTML = '';
     if (els.tdRDOList) els.tdRDOList.innerHTML = '';
+    if (els.tdMeta) els.tdMeta.innerHTML = '';
+    if (els.tdEditForm) els.tdEditForm.innerHTML = '';
   }
 
   // ========== DASHBOARD ==========
@@ -286,6 +301,7 @@
       tdMeta: qs('#tdMeta'),
       tdDesc: qs('#tdDesc'),
       tdRDOList: qs('#tdRDOList'),
+      tdEditForm: qs('#tdEditForm'),
       btnLogout: qs('#btnLogout'),
       btnHamb: qs('#btnHamb'),
       btnTV: qs('#btnTV'),
@@ -484,8 +500,34 @@ openTicketDetail(t, rowEl){
 
   const list = DB.state.rdosByTicket[t.id] || [];
   if (els.tdRDOList) els.tdRDOList.innerHTML = list.map(i=>`<li>${i}</li>`).join('') || '<li>Nenhum RDO registrado.</li>';
-  qs('#tdEdit')?.addEventListener('click', ()=> UI.editTicket(t));
-  qs('#tdDel')?.addEventListener('click', ()=> UI.deleteTicket(t));
+  if (els.tdEditForm){
+    const fieldsHTML = TICKET_FIELDS.map(f=>{
+      const label = TICKET_FIELD_LABELS[f];
+      const val = t[f] ?? '';
+      if (f === 'descricao')
+        return `<div class="field"><label>${label}</label><textarea name="${f}">${val}</textarea></div>`;
+      return `<div class="field"><label>${label}</label><input name="${f}" value="${val}"/></div>`;
+    }).join('');
+    els.tdEditForm.innerHTML = `
+      <form id="editTicketForm" class="edit-form">
+        ${fieldsHTML}
+        <div class="actions">
+          <button type="submit" class="save-btn">Salvar</button>
+          <button type="button" class="del-btn" id="btnDelTicket">Excluir</button>
+        </div>
+      </form>`;
+    const form = qs('#editTicketForm', els.tdEditForm);
+    form?.addEventListener('submit', ev=>{
+      ev.preventDefault();
+      const fd = new FormData(form);
+      const updated = {};
+      TICKET_FIELDS.forEach(f=> updated[f] = fd.get(f));
+      updated.concl = Number(updated.concl);
+      updated.prazo = Number(updated.prazo);
+      UI.editTicket(t, updated);
+    });
+    qs('#btnDelTicket', els.tdEditForm)?.addEventListener('click', ()=> UI.deleteTicket(t));
+  }
 
   if (!els._subtabsBound && els.ticketDetail) {
     els.ticketDetail.addEventListener('click', (ev)=>{
@@ -517,13 +559,7 @@ openTicketDetail(t, rowEl){
   if (firstPanel){ firstPanel.classList.add('active'); firstPanel.style.display=''; }
 },
 
-editTicket(t){
-  const fields = ['id','createdAt','meetPoint','dupla','concl','prazo','resumo','solicitante','telefone','descricao'];
-  const updated = { ...t };
-  fields.forEach(f => {
-    const val = prompt(`Novo ${f}`, t[f] ?? '');
-    if (val !== null) updated[f] = val;
-  });
+editTicket(t, updated){
   if (updated.id !== t.id){
     if (DB.state.rdosByTicket[t.id]){ DB.state.rdosByTicket[updated.id] = DB.state.rdosByTicket[t.id]; delete DB.state.rdosByTicket[t.id]; }
     if (DB.state.historyByTicket[t.id]){ DB.state.historyByTicket[updated.id] = DB.state.historyByTicket[t.id]; delete DB.state.historyByTicket[t.id]; }

--- a/app.js
+++ b/app.js
@@ -501,23 +501,47 @@ openTicketDetail(t, rowEl){
   const list = DB.state.rdosByTicket[t.id] || [];
   if (els.tdRDOList) els.tdRDOList.innerHTML = list.map(i=>`<li>${i}</li>`).join('') || '<li>Nenhum RDO registrado.</li>';
   if (els.tdEditForm){
-    const fieldsHTML = TICKET_FIELDS.map(f=>{
-      const label = TICKET_FIELD_LABELS[f];
-      const val = t[f] ?? '';
-      if (f === 'descricao')
-        return `<div class="field"><label>${label}</label><textarea name="${f}">${val}</textarea></div>`;
-      return `<div class="field"><label>${label}</label><input name="${f}" value="${val}"/></div>`;
-    }).join('');
-    els.tdEditForm.innerHTML = `
-      <form id="editTicketForm" class="edit-form">
-        ${fieldsHTML}
-        <div class="actions">
-          <button type="submit" class="save-btn">Salvar</button>
-          <button type="button" class="del-btn" id="btnDelTicket">Excluir</button>
-        </div>
-      </form>`;
-    const form = qs('#editTicketForm', els.tdEditForm);
-    form?.addEventListener('submit', ev=>{
+    els.tdEditForm.innerHTML = '';
+    const form = document.createElement('form');
+    form.id = 'editTicketForm';
+    form.className = 'edit-form';
+
+    TICKET_FIELDS.forEach(f => {
+      const wrap = document.createElement('div');
+      wrap.className = 'field';
+      const label = document.createElement('label');
+      label.textContent = TICKET_FIELD_LABELS[f];
+      let inp;
+      if (f === 'descricao') {
+        inp = document.createElement('textarea');
+        inp.value = t[f] ?? '';
+      } else {
+        inp = document.createElement('input');
+        inp.value = t[f] ?? '';
+      }
+      inp.name = f;
+      wrap.appendChild(label);
+      wrap.appendChild(inp);
+      form.appendChild(wrap);
+    });
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    const btnSave = document.createElement('button');
+    btnSave.type = 'submit';
+    btnSave.className = 'save-btn';
+    btnSave.textContent = 'Salvar';
+    const btnDel = document.createElement('button');
+    btnDel.type = 'button';
+    btnDel.className = 'del-btn';
+    btnDel.id = 'btnDelTicket';
+    btnDel.textContent = 'Excluir';
+    actions.appendChild(btnSave);
+    actions.appendChild(btnDel);
+    form.appendChild(actions);
+    els.tdEditForm.appendChild(form);
+
+    form.addEventListener('submit', ev=>{
       ev.preventDefault();
       const fd = new FormData(form);
       const updated = {};
@@ -526,7 +550,7 @@ openTicketDetail(t, rowEl){
       updated.prazo = Number(updated.prazo);
       UI.editTicket(t, updated);
     });
-    qs('#btnDelTicket', els.tdEditForm)?.addEventListener('click', ()=> UI.deleteTicket(t));
+    btnDel.addEventListener('click', ()=> UI.deleteTicket(t));
   }
 
   if (!els._subtabsBound && els.ticketDetail) {

--- a/app.js
+++ b/app.js
@@ -11,7 +11,14 @@
 
   let CURRENT_USER = 'admin';
 
-  // ========== MOCK DE DADOS ==========
+  // ========== MOCK DE DADOS (carregado de db.json) =========
+  function genHistory(finalPct){
+    const pts = []; let v = Math.max(5, Math.min(90, finalPct - 20));
+    for(let i=0;i<8;i++){ v = Math.min(100, Math.max(0, v + (Math.random()*18-5))); pts.push(Math.round(v)); }
+    pts[7] = finalPct;
+    return pts;
+  }
+
   const DB = {
     state: {
       tickets: [],
@@ -20,50 +27,17 @@
       rdosByTicket: {},
       historyByTicket: {}, // série de progresso (8 pontos)
     },
-    bootstrap(){
-      this.state.tickets = [
-        { id:'CH-1021', createdAt:'2025-08-06T09:35:00', meetPoint:'Centro - Loja 12', dupla:'Ana & João', concl:62, prazo:45, resumo:'Queda intermitente na rede local.', solicitante:'Carlos M.', telefone:'(21) 90000-1021', descricao:'Queda intermitente na rede local. Equipamentos reiniciam sem aviso, requer verificação detalhada.' },
-        { id:'CH-1022', createdAt:'2025-08-06T14:10:00', meetPoint:'Zona Sul - Posto 3', dupla:'Marcos & Lia', concl:35, prazo:22, resumo:'Atualização de firmware pendente.', solicitante:'Júlia P.', telefone:'(21) 90000-1022', descricao:'Atualização de firmware pendente em vários roteadores da filial.' },
-        { id:'CH-1023', createdAt:'2025-08-07T18:55:00', meetPoint:'Barra - Quiosque B', dupla:'Rafa & Gui', concl:88, prazo:76, resumo:'Troca de ONU e reconfiguração.', solicitante:'Ricardo L.', telefone:'(21) 90000-1023', descricao:'Troca de ONU e reconfiguração completa do enlace principal.' },
-        { id:'CH-1024', createdAt:'2025-08-07T07:20:00', meetPoint:'Centro - Praça 7', dupla:'Paula & Leo', concl:20, prazo:12, resumo:'Visita inicial, aguardando acesso.', solicitante:'Mariana S.', telefone:'(21) 90000-1024', descricao:'Visita inicial, aguardando acesso ao edifício para diagnóstico.' },
-        { id:'CH-1025', createdAt:'2025-08-08T11:45:00', meetPoint:'Niterói - Estação', dupla:'Bia & Tom', concl:58, prazo:40, resumo:'Ajuste de alinhamento de antena.', solicitante:'Eduardo T.', telefone:'(21) 90000-1025', descricao:'Ajuste de alinhamento de antena para melhora de sinal.' },
-        { id:'CH-1026', createdAt:'2025-08-08T12:30:00', meetPoint:'Copacabana - Posto 5', dupla:'Vivi & Dan', concl:12, prazo:8, resumo:'Inspeção de cabeamento.', solicitante:'Fernanda B.', telefone:'(21) 90000-1026', descricao:'Inspeção de cabeamento em rede interna do cliente.' },
-        { id:'CH-1027', createdAt:'2025-08-08T13:05:00', meetPoint:'Tijuca - Saens Peña', dupla:'Caio & Nina', concl:42, prazo:51, resumo:'Oscilação de potência no enlace.', solicitante:'Sérgio A.', telefone:'(21) 90000-1027', descricao:'Oscilação de potência no enlace precisa de análise de interferência.' },
-        { id:'CH-1028', createdAt:'2025-08-08T13:50:00', meetPoint:'Centro - Ed. Rio', dupla:'Leo & Tati', concl:74, prazo:60, resumo:'Revisão de configuração de roteador.', solicitante:'Patrícia F.', telefone:'(21) 90000-1028', descricao:'Revisão de configuração de roteador e otimização de QoS.' },
-        { id:'CH-1029', createdAt:'2025-08-08T14:25:00', meetPoint:'Ilha - Galeão', dupla:'Iuri & Fê', concl:28, prazo:30, resumo:'Troca de patch cords danificados.', solicitante:'Henrique C.', telefone:'(21) 90000-1029', descricao:'Troca de patch cords danificados e testes de continuidade.' },
-        { id:'CH-1030', createdAt:'2025-08-08T15:10:00', meetPoint:'Barra - Shopping X', dupla:'Gabi & Renan', concl:91, prazo:85, resumo:'Homologação final do link.', solicitante:'Bianca R.', telefone:'(21) 90000-1030', descricao:'Homologação final do link com validação de performance.' },
-      ];
-      this.state.projects = [
-        { id:'PR-2001', name:'Integração CRM', desc:'Conectar pipeline de vendas ao painel.', prazo:'2025-09-15', dias:40, pessoas:5, diasTrab:22, pct:55 },
-        { id:'PR-2002', name:'App Mobile Field', desc:'Aplicativo de campo para equipes externas.', prazo:'2025-10-02', dias:55, pessoas:7, diasTrab:18, pct:32 },
-        { id:'PR-2003', name:'Relatórios V2', desc:'Dashboards executivos e exportações.', prazo:'2025-08-30', dias:20, pessoas:3, diasTrab:12, pct:70 },
-        { id:'PR-2004', name:'Onboarding Rápido', desc:'Fluxo simplificado para novos clientes.', prazo:'2025-09-05', dias:18, pessoas:2, diasTrab:9, pct:48 },
-        { id:'PR-2005', name:'Chatbot L2', desc:'Bot de triagem de chamados nível 2.', prazo:'2025-11-01', dias:60, pessoas:6, diasTrab:10, pct:20 },
-        { id:'PR-2006', name:'Portal Parceiros', desc:'Área para parceiros externos.', prazo:'2025-12-15', dias:75, pessoas:8, diasTrab:15, pct:26 },
-      ];
-      this.state.materialsByProject = {
-        'PR-2001': ['API Key CRM','Webhook /lead-created','Tabela staging_crm','Doc mapeamento campos'],
-        'PR-2002': ['Design Figma Mobile','SDK Camera','GPS Provider','Guia de acessibilidade'],
-        'PR-2003': ['Spec KPIs','Lib export CSV','Template PDF','Exemplos de queries'],
-        'PR-2004': ['Flowchart onboarding','Email templates','Checklist CS'],
-        'PR-2005': ['Dataset intents L2','NLP model v0.9','Playbook fallback'],
-        'PR-2006': ['Contrato parceiro','Guia branding','Endpoint /partners'],
-      };
-      this.state.rdosByTicket = {
-        'CH-1021': ['RDO 08/06 - inspeção inicial','RDO 08/07 - ajuste de parâmetros'],
-        'CH-1023': ['RDO 08/07 - troca de ONU','RDO 08/08 - testes finais'],
-      };
+    async load(){
+      const res = await fetch('db.json');
+      const data = await res.json();
+      Object.assign(this.state, data);
+      this.state.historyByTicket = {};
       this.state.tickets.forEach(t=>{
         this.state.historyByTicket[t.id] = genHistory(t.concl);
       });
-      function genHistory(finalPct){
-        const pts = []; let v = Math.max(5, Math.min(90, finalPct - 20));
-        for(let i=0;i<8;i++){ v = Math.min(100, Math.max(0, v + (Math.random()*18-5))); pts.push(Math.round(v)); }
-        pts[7] = finalPct;
-        return pts;
-      }
     }
   };
+
 
   // ========== TEMPLATES ==========
   const tpl = {
@@ -148,7 +122,11 @@
             <div class="ticket-detail" id="ticketDetail" style="display:none; background:#0f131a; border:1px solid var(--card-border); border-radius:12px; padding:12px; margin-top:8px">
               <header style="display:flex; justify-content:space-between; align-items:center; margin-bottom:6px">
                 <strong id="tdTitle">Chamado</strong>
-                <span class="badge" id="tdPct">0%</span>
+                <div style="display:flex; gap:6px; align-items:center">
+                  <span class="badge" id="tdPct">0%</span>
+                  <button class="edit-btn" id="tdEdit">Editar</button>
+                  <button class="del-btn" id="tdDel">Excluir</button>
+                </div>
               </header>
               <div id="tdMeta" style="display:flex; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px"></div>
 
@@ -244,11 +222,11 @@
         user.value=''; pass.value=''; enableContinueIfFilled();
       }, 200);
     };
-    const goToDashboard = () => {
+    const goToDashboard = async () => {
       viewLogin.style.display = 'none';
       viewDash.style.display = 'block';
       CURRENT_USER = (user.value.trim() || 'admin');
-      DB.bootstrap();
+      await DB.load();
       initDashboard();
     };
 
@@ -506,6 +484,8 @@ openTicketDetail(t, rowEl){
 
   const list = DB.state.rdosByTicket[t.id] || [];
   if (els.tdRDOList) els.tdRDOList.innerHTML = list.map(i=>`<li>${i}</li>`).join('') || '<li>Nenhum RDO registrado.</li>';
+  qs('#tdEdit')?.addEventListener('click', ()=> UI.editTicket(t));
+  qs('#tdDel')?.addEventListener('click', ()=> UI.deleteTicket(t));
 
   if (!els._subtabsBound && els.ticketDetail) {
     els.ticketDetail.addEventListener('click', (ev)=>{
@@ -535,6 +515,57 @@ openTicketDetail(t, rowEl){
   const firstPanel = qs('#tdDesc', els.ticketDetail);
   if (first) first.classList.add('active');
   if (firstPanel){ firstPanel.classList.add('active'); firstPanel.style.display=''; }
+},
+
+editTicket(t){
+  const fields = ['id','createdAt','meetPoint','dupla','concl','prazo','resumo','solicitante','telefone','descricao'];
+  const updated = { ...t };
+  fields.forEach(f => {
+    const val = prompt(`Novo ${f}`, t[f] ?? '');
+    if (val !== null) updated[f] = val;
+  });
+  if (updated.id !== t.id){
+    if (DB.state.rdosByTicket[t.id]){ DB.state.rdosByTicket[updated.id] = DB.state.rdosByTicket[t.id]; delete DB.state.rdosByTicket[t.id]; }
+    if (DB.state.historyByTicket[t.id]){ DB.state.historyByTicket[updated.id] = DB.state.historyByTicket[t.id]; delete DB.state.historyByTicket[t.id]; }
+  }
+  Object.assign(t, updated);
+  DB.state.historyByTicket[t.id] = genHistory(t.concl);
+  UI.renderTickets();
+  UI.openTicketDetail(t);
+},
+
+deleteTicket(t){
+  if(!confirm('Excluir chamado?')) return;
+  DB.state.tickets = DB.state.tickets.filter(x=>x!==t);
+  delete DB.state.rdosByTicket[t.id];
+  delete DB.state.historyByTicket[t.id];
+  UI.renderTickets();
+  clearTicketDetail(els);
+},
+
+editProject(p){
+  const fields = ['id','name','desc','prazo','dias','pessoas','diasTrab','pct'];
+  const updated = { ...p };
+  fields.forEach(f => {
+    const val = prompt(`Novo ${f}`, p[f] ?? '');
+    if (val !== null) updated[f] = val;
+  });
+  if (updated.id !== p.id){
+    if (DB.state.materialsByProject[p.id]){ DB.state.materialsByProject[updated.id] = DB.state.materialsByProject[p.id]; delete DB.state.materialsByProject[p.id]; }
+  }
+  Object.assign(p, updated);
+  UI.renderProjects();
+  UI.updateProjectArrows();
+  UI.openProjectDetailInline(p);
+},
+
+deleteProject(p){
+  if(!confirm('Excluir projeto?')) return;
+  DB.state.projects = DB.state.projects.filter(x=>x!==p);
+  delete DB.state.materialsByProject[p.id];
+  UI.renderProjects();
+  UI.updateProjectArrows();
+  if(els.projDetailsInline) els.projDetailsInline.innerHTML = '';
 },
 
       // ===== Charts (andamento) =====
@@ -609,7 +640,11 @@ openTicketDetail(t, rowEl){
         els.projDetailsInline.innerHTML = `
           <header style="display:flex; justify-content:space-between; align-items:center; margin-bottom:6px">
             <strong>${p.name}</strong>
-            <span class="badge">${p.pct}%</span>
+            <div style="display:flex; gap:6px; align-items:center">
+              <span class="badge">${p.pct}%</span>
+              <button class="edit-btn" id="projEdit">Editar</button>
+              <button class="del-btn" id="projDel">Excluir</button>
+            </div>
           </header>
           <div style="display:flex; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px">
             <span><b>Prazo:</b> ${new Date(p.prazo).toLocaleDateString('pt-BR')}</span>
@@ -622,6 +657,8 @@ openTicketDetail(t, rowEl){
             <h3 style="font-size:13px; color:var(--muted); margin-bottom:6px">Materiais</h3>
             <ul style="margin-left:18px; display:grid; gap:4px">${mats.map(m=>`<li>${m}</li>`).join('')}</ul>
           </div>`;
+        qs('#projEdit')?.addEventListener('click', ()=> UI.editProject(p));
+        qs('#projDel')?.addEventListener('click', ()=> UI.deleteProject(p));
       },
     };
   // ===== Helpers do Modo TV (fora do UI!) =====

--- a/app.js
+++ b/app.js
@@ -652,57 +652,20 @@ openTicketDetail(t, rowEl){
           </div>`;
       },
     };
-    // ===== Helpers do Modo TV (fora do UI!) =====
+  // ===== Helpers do Modo TV (fora do UI!) =====
 function isTV(){
   return document.body.classList.contains('tv-mode');
 }
 
+const sizeContentForTV = () => {
+  const top = document.querySelector('.top.panel');
+  const content = document.getElementById('dashboardContent');
+  if (!top || !content) return;
+  content.style.height = (window.innerHeight - top.offsetHeight) + 'px';
+};
+
 function toggleTVMode(){
   const fsEl = document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement;
-
-  if (!fsEl) {
-    const root = document.documentElement;
-    const req = root.requestFullscreen || root.webkitRequestFullscreen || root.msRequestFullscreen;
-    if (req) req.call(root).catch?.(e => console.warn('Fullscreen error:', e));
-    document.body.classList.add('tv-mode');
-  } else {
-    const exit = document.exitFullscreen || document.webkitExitFullscreen || document.msExitFullscreen;
-    if (exit) exit.call(document).catch?.(e => console.warn('Exit FS error:', e));
-    document.body.classList.remove('tv-mode');
-  }
-
-  // re-render pra aplicar/remover a coluna Resumo e extras dos projetos
-  UI.renderTickets();
-  UI.renderProjects();
-  UI.updateProjectArrows();
-}
-
-// Sincroniza classe ao sair por ESC/gesto
-['fullscreenchange','webkitfullscreenchange','msfullscreenchange'].forEach(ev=>{
-  document.addEventListener(ev, ()=>{
-    const fsEl = document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement;
-    document.body.classList.toggle('tv-mode', !!fsEl);
-    UI.renderTickets();
-    UI.renderProjects();
-    UI.updateProjectArrows();
-  });
-});
-
-// Botão TV
-els.btnTV?.addEventListener('click', toggleTVMode);
-
-    // ====== Modo TV (fullscreen + layout) ======
-    els.btnTV?.addEventListener('click', toggleTVMode);
-
-    function toggleTVMode(){
-  const fsEl = document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement;
-
-  const sizeContentForTV = () => {
-    const top = document.querySelector('.top.panel');
-    const content = document.getElementById('dashboardContent');
-    if (!top || !content) return;
-    content.style.height = (window.innerHeight - top.offsetHeight) + 'px';
-  };
 
   if (!fsEl) {
     const root = document.documentElement;
@@ -719,15 +682,35 @@ els.btnTV?.addEventListener('click', toggleTVMode);
     if (content) content.style.height = '';
     window.removeEventListener('resize', sizeContentForTV);
   }
+
+  // re-render pra aplicar/remover a coluna Resumo e extras dos projetos
+  UI.renderTickets();
+  UI.renderProjects();
+  UI.updateProjectArrows();
 }
 
+// Sincroniza classe ao sair por ESC/gesto
+['fullscreenchange','webkitfullscreenchange','msfullscreenchange'].forEach(ev=>{
+  document.addEventListener(ev, ()=>{
+    const fsEl = document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement;
+    if (!fsEl) {
+      document.body.classList.remove('tv-mode');
+      const content = document.getElementById('dashboardContent');
+      if (content) content.style.height = '';
+      window.removeEventListener('resize', sizeContentForTV);
+    } else {
+      document.body.classList.add('tv-mode');
+      sizeContentForTV();
+      window.addEventListener('resize', sizeContentForTV);
+    }
+    UI.renderTickets();
+    UI.renderProjects();
+    UI.updateProjectArrows();
+  });
+});
 
-    ['fullscreenchange','webkitfullscreenchange','msfullscreenchange'].forEach(ev=>{
-      document.addEventListener(ev, ()=>{
-        const fsEl = document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement;
-        if (!fsEl) document.body.classList.remove('tv-mode');
-      });
-    });
+// Botão TV
+els.btnTV?.addEventListener('click', toggleTVMode);
 
     // ====== listeners globais (blindados) ======
     els.btnLogout?.addEventListener('click', ()=>{ location.reload(); });

--- a/app.js
+++ b/app.js
@@ -375,7 +375,14 @@
         this.renderSLAChart(t.concl, t.prazo, 'chartSLA');
       },
 
-      renderAll(){ this.renderTickets(); this.renderProjects(); this.updateProjectArrows(); },
+      renderAll(){
+        this.renderTickets();
+        this.renderProjects();
+        this.updateProjectArrows();
+        if(!document.body.classList.contains('tickets-page') && !document.body.classList.contains('projects-page')){
+          this._renderOverview();
+        }
+      },
 
       renderTickets(){
   els.ticketsTableBody.innerHTML = '';
@@ -397,18 +404,18 @@
   DB.state.tickets.forEach(t => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td><button class="linklike" data-id="${t.id}">${t.id}</button></td>
-      <td>${fmtDate(t.createdAt)}</td>
-      <td>${t.meetPoint}</td>
-      <td>${t.dupla}</td>
-      ${isTV() ? `<td class="col-resumo" title="${t.resumo}">${t.resumo}</td>` : ''}
-      <td>
+      <td data-label="ID do chamado"><button class="linklike" data-id="${t.id}">${t.id}</button></td>
+      <td data-label="Data de criação">${fmtDate(t.createdAt)}</td>
+      <td data-label="Ponto de encontro">${t.meetPoint}</td>
+      <td data-label="Dupla">${t.dupla}</td>
+      ${isTV() ? `<td class="col-resumo" data-label="Resumo" title="${t.resumo}">${t.resumo}</td>` : ''}
+      <td data-label="% de conclusão">
         <div class="prog">
           <div class="nums"><span>Concl.: <b>${t.concl}%</b></span></div>
           <div class="progress"><i style="width:${t.concl}%"></i></div>
         </div>
       </td>
-      <td>
+      <td data-label="% de prazo">
         <div class="prog">
           <div class="nums"><span>Prazo: <b>${t.prazo}%</b></span></div>
           <div class="progress"><i style="width:${t.prazo}%"></i></div>

--- a/app.js
+++ b/app.js
@@ -22,16 +22,16 @@
     },
     bootstrap(){
       this.state.tickets = [
-        { id:'CH-1021', createdAt: '2025-08-06T09:35:00', meetPoint:'Centro - Loja 12', dupla:'Ana & João', concl:62, prazo:45, resumo:'Queda intermitente na rede local.' },
-        { id:'CH-1022', createdAt: '2025-08-06T14:10:00', meetPoint:'Zona Sul - Posto 3', dupla:'Marcos & Lia', concl:35, prazo:22, resumo:'Atualização de firmware pendente.' },
-        { id:'CH-1023', createdAt: '2025-08-07T18:55:00', meetPoint:'Barra - Quiosque B', dupla:'Rafa & Gui', concl:88, prazo:76, resumo:'Troca de ONU e reconfiguração.' },
-        { id:'CH-1024', createdAt: '2025-08-07T07:20:00', meetPoint:'Centro - Praça 7', dupla:'Paula & Leo', concl:20, prazo:12, resumo:'Visita inicial, aguardando acesso.' },
-        { id:'CH-1025', createdAt: '2025-08-08T11:45:00', meetPoint:'Niterói - Estação', dupla:'Bia & Tom', concl:58, prazo:40, resumo:'Ajuste de alinhamento de antena.' },
-        { id:'CH-1026', createdAt: '2025-08-08T12:30:00', meetPoint:'Copacabana - Posto 5', dupla:'Vivi & Dan', concl:12, prazo:8,  resumo:'Inspeção de cabeamento.' },
-        { id:'CH-1027', createdAt: '2025-08-08T13:05:00', meetPoint:'Tijuca - Saens Peña', dupla:'Caio & Nina', concl:42, prazo:51, resumo:'Oscilação de potência no enlace.' },
-        { id:'CH-1028', createdAt: '2025-08-08T13:50:00', meetPoint:'Centro - Ed. Rio', dupla:'Leo & Tati', concl:74, prazo:60, resumo:'Revisão de configuração de roteador.' },
-        { id:'CH-1029', createdAt: '2025-08-08T14:25:00', meetPoint:'Ilha - Galeão', dupla:'Iuri & Fê', concl:28, prazo:30, resumo:'Troca de patch cords danificados.' },
-        { id:'CH-1030', createdAt: '2025-08-08T15:10:00', meetPoint:'Barra - Shopping X', dupla:'Gabi & Renan', concl:91, prazo:85, resumo:'Homologação final do link.' },
+        { id:'CH-1021', createdAt:'2025-08-06T09:35:00', meetPoint:'Centro - Loja 12', dupla:'Ana & João', concl:62, prazo:45, resumo:'Queda intermitente na rede local.', solicitante:'Carlos M.', telefone:'(21) 90000-1021', descricao:'Queda intermitente na rede local. Equipamentos reiniciam sem aviso, requer verificação detalhada.' },
+        { id:'CH-1022', createdAt:'2025-08-06T14:10:00', meetPoint:'Zona Sul - Posto 3', dupla:'Marcos & Lia', concl:35, prazo:22, resumo:'Atualização de firmware pendente.', solicitante:'Júlia P.', telefone:'(21) 90000-1022', descricao:'Atualização de firmware pendente em vários roteadores da filial.' },
+        { id:'CH-1023', createdAt:'2025-08-07T18:55:00', meetPoint:'Barra - Quiosque B', dupla:'Rafa & Gui', concl:88, prazo:76, resumo:'Troca de ONU e reconfiguração.', solicitante:'Ricardo L.', telefone:'(21) 90000-1023', descricao:'Troca de ONU e reconfiguração completa do enlace principal.' },
+        { id:'CH-1024', createdAt:'2025-08-07T07:20:00', meetPoint:'Centro - Praça 7', dupla:'Paula & Leo', concl:20, prazo:12, resumo:'Visita inicial, aguardando acesso.', solicitante:'Mariana S.', telefone:'(21) 90000-1024', descricao:'Visita inicial, aguardando acesso ao edifício para diagnóstico.' },
+        { id:'CH-1025', createdAt:'2025-08-08T11:45:00', meetPoint:'Niterói - Estação', dupla:'Bia & Tom', concl:58, prazo:40, resumo:'Ajuste de alinhamento de antena.', solicitante:'Eduardo T.', telefone:'(21) 90000-1025', descricao:'Ajuste de alinhamento de antena para melhora de sinal.' },
+        { id:'CH-1026', createdAt:'2025-08-08T12:30:00', meetPoint:'Copacabana - Posto 5', dupla:'Vivi & Dan', concl:12, prazo:8, resumo:'Inspeção de cabeamento.', solicitante:'Fernanda B.', telefone:'(21) 90000-1026', descricao:'Inspeção de cabeamento em rede interna do cliente.' },
+        { id:'CH-1027', createdAt:'2025-08-08T13:05:00', meetPoint:'Tijuca - Saens Peña', dupla:'Caio & Nina', concl:42, prazo:51, resumo:'Oscilação de potência no enlace.', solicitante:'Sérgio A.', telefone:'(21) 90000-1027', descricao:'Oscilação de potência no enlace precisa de análise de interferência.' },
+        { id:'CH-1028', createdAt:'2025-08-08T13:50:00', meetPoint:'Centro - Ed. Rio', dupla:'Leo & Tati', concl:74, prazo:60, resumo:'Revisão de configuração de roteador.', solicitante:'Patrícia F.', telefone:'(21) 90000-1028', descricao:'Revisão de configuração de roteador e otimização de QoS.' },
+        { id:'CH-1029', createdAt:'2025-08-08T14:25:00', meetPoint:'Ilha - Galeão', dupla:'Iuri & Fê', concl:28, prazo:30, resumo:'Troca de patch cords danificados.', solicitante:'Henrique C.', telefone:'(21) 90000-1029', descricao:'Troca de patch cords danificados e testes de continuidade.' },
+        { id:'CH-1030', createdAt:'2025-08-08T15:10:00', meetPoint:'Barra - Shopping X', dupla:'Gabi & Renan', concl:91, prazo:85, resumo:'Homologação final do link.', solicitante:'Bianca R.', telefone:'(21) 90000-1030', descricao:'Homologação final do link com validação de performance.' },
       ];
       this.state.projects = [
         { id:'PR-2001', name:'Integração CRM', desc:'Conectar pipeline de vendas ao painel.', prazo:'2025-09-15', dias:40, pessoas:5, diasTrab:22, pct:55 },
@@ -153,13 +153,12 @@
               <div id="tdMeta" style="display:flex; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px"></div>
 
               <div class="subtabs" style="display:flex; gap:8px; border-bottom:1px solid var(--card-border); margin-top:10px">
-                <button class="subtab active" data-tab="tdCharts" style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Gráficos</button>
+                <button class="subtab active" data-tab="tdDesc" style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Descrição</button>
                 <button class="subtab" data-tab="tdNotes" style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Anotações</button>
                 <button class="subtab" data-tab="tdRDO"   style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">RDO's</button>
                 <button class="subtab" data-tab="tdObs"   style="background:transparent;border:1px solid var(--card-border);border-bottom:0;padding:8px 12px;border-top-left-radius:10px;border-top-right-radius:10px;cursor:pointer;color:var(--text)">Observações</button>
               </div>
-
-              <div class="subtab-panel active" id="tdCharts" style="padding-top:10px"></div>
+              <div class="subtab-panel active" id="tdDesc" style="padding-top:10px"></div>
               <div class="subtab-panel" id="tdNotes" style="display:none;padding-top:10px">
                 <textarea style="width:100%; min-height:120px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Escreva anotações do chamado..."></textarea>
               </div>
@@ -283,7 +282,7 @@
   // ========== helpers ==========
   function clearTicketDetail(els){
     if (!els.ticketDetail) return;
-    if (els.tdCharts) els.tdCharts.innerHTML = '';
+    if (els.tdDesc) els.tdDesc.innerHTML = '';
     if (els.tdRDOList) els.tdRDOList.innerHTML = '';
   }
 
@@ -307,7 +306,7 @@
       tdTitle: qs('#tdTitle'),
       tdPct: qs('#tdPct'),
       tdMeta: qs('#tdMeta'),
-      tdCharts: qs('#tdCharts'),
+      tdDesc: qs('#tdDesc'),
       tdRDOList: qs('#tdRDOList'),
       btnLogout: qs('#btnLogout'),
       btnHamb: qs('#btnHamb'),
@@ -488,30 +487,21 @@ openTicketDetail(t, rowEl){
   this.selectTicket(t, rowEl);
   this.setActiveTab('tickets');
 
-  if (els.tdTitle) els.tdTitle.textContent = `${t.id} — ${t.meetPoint}`;
+  if (els.tdTitle) els.tdTitle.textContent = t.id;
   if (els.tdPct) els.tdPct.textContent = `${t.concl}%`;
   if (els.tdMeta) els.tdMeta.innerHTML = `
     <span><b>Data:</b> ${fmtDate(t.createdAt)}</span>
+    <span><b>Aberto por:</b> ${t.solicitante}</span>
+    <span><b>Contato:</b> ${t.telefone}</span>
+    <span><b>Ponto de encontro:</b> ${t.meetPoint}</span>
     <span><b>Dupla:</b> ${t.dupla}</span>
-    <span><b>Resumo:</b> ${t.resumo}</span>
     <span><b>Prazo consumido:</b> ${t.prazo}%</span>`;
 
-  if (els.tdCharts) {
-    els.tdCharts.innerHTML = `
-      <div class="pie-grid">
-        <div class="donut">
-          <svg id="tdPieConcl" viewBox="0 0 36 36"></svg>
-          <div class="lbl">Conclusão</div>
-          <div class="val">${t.concl}%</div>
-        </div>
-        <div class="donut">
-          <svg id="tdPiePrazo" viewBox="0 0 36 36"></svg>
-          <div class="lbl">Prazo consumido</div>
-          <div class="val">${t.prazo}%</div>
-        </div>
-      </div>`;
-    this.renderPie('tdPieConcl', t.concl);
-    this.renderPie('tdPiePrazo', t.prazo);
+  if (els.tdDesc) {
+    els.tdDesc.innerHTML = `
+      <p><b>Resumo:</b> ${t.resumo}</p>
+      <p>${t.descricao}</p>
+    `;
   }
 
   const list = DB.state.rdosByTicket[t.id] || [];
@@ -535,14 +525,14 @@ openTicketDetail(t, rowEl){
     els._subtabsBound = true;
   }
 
-  // Estado inicial (ativa "Gráficos")
+    // Estado inicial (ativa "Descrição")
   const tabs = qsa('.subtab', els.ticketDetail);
   const panels = qsa('.subtab-panel', els.ticketDetail);
   tabs.forEach(tb=> tb.classList.remove('active'));
   panels.forEach(p=> { p.classList.remove('active'); p.style.display='none'; });
 
-  const first = qs('.subtab[data-tab="tdCharts"]', els.ticketDetail);
-  const firstPanel = qs('#tdCharts', els.ticketDetail);
+  const first = qs('.subtab[data-tab="tdDesc"]', els.ticketDetail);
+  const firstPanel = qs('#tdDesc', els.ticketDetail);
   if (first) first.classList.add('active');
   if (firstPanel){ firstPanel.classList.add('active'); firstPanel.style.display=''; }
 },
@@ -595,24 +585,6 @@ openTicketDetail(t, rowEl){
             <text x="2" y="8">Prazo consumido: ${p}%</text>
             <text x="2" y="36">Conclusão: ${c}%</text>
           </g>`;
-      },
-
-      renderPie(targetId, pct){
-        const svg = document.getElementById(targetId);
-        if (!svg) return;
-        const p = Math.max(0, Math.min(100, pct||0));
-        const r = 15.915, c = 2*Math.PI*r, dash = (p/100)*c;
-        const gid = `gradPie-${targetId}`; // único por gráfico
-        svg.innerHTML = `
-          <defs>
-            <linearGradient id="${gid}" x1="0" x2="0" y1="0" y2="1">
-              <stop offset="0%" stop-color="${cssVar('--brand')}"/>
-              <stop offset="100%" stop-color="${cssVar('--brand-strong')}"/>
-            </linearGradient>
-          </defs>
-          <circle cx="18" cy="18" r="${r}" fill="none" stroke="rgba(255,255,255,.15)" stroke-width="3"/>
-          <circle cx="18" cy="18" r="${r}" fill="none" stroke="url(#${gid})" stroke-width="3"
-                  stroke-dasharray="${dash} ${c-dash}" stroke-linecap="round" transform="rotate(-90 18 18)"/>`;
       },
 
       // ====== Projects list + inline details ======

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -34,3 +34,13 @@ body{
 /* barras de progresso padrão */
 .progress{ height:8px; background:#0f131a; border:1px solid var(--card-border); border-radius:8px; overflow:hidden }
 .progress > i{ display:block; height:100%; background: linear-gradient(180deg, var(--brand), var(--brand-strong)); width:0% }
+
+/* Ajustes para telas pequenas */
+@media (max-width: 900px){
+  body{
+    display:block;
+    place-items:initial;
+    overflow:auto;
+  }
+  .glow{display:none}
+}

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -49,6 +49,10 @@
 
 /* Gráficos (overview) */
 .charts{ grid-column: span 5; }
+
+@media (max-width: 900px){
+  #sectionCharts{ display:flex; }
+}
 .chart{ background:#0f131a; border:1px dashed rgba(255,255,255,.12); border-radius:12px; padding:10px }
 .chart h3{ font-size:13px; color:var(--muted); margin-bottom:6px }
 .svg-wrap{ width:100%; height:140px }
@@ -372,3 +376,13 @@ body.tv-mode .section{
 
 /* Quando sair do modo TV, não deixa "fantasma" de alturas */
 .content.panel{ min-height: 0; } /* garante que filhos possam rolar */
+
+/* ----- Tickets como cartões no mobile ----- */
+@media (max-width: 600px){
+  #ticketsTable thead{ display:none }
+  #ticketsTable, #ticketsTable tbody, #ticketsTable tr, #ticketsTable td{ display:block; width:100% }
+  #ticketsTable tr{ background:#0f131a; border:1px solid var(--card-border); border-radius:10px; padding:8px; margin-bottom:8px }
+  #ticketsTable td{ border:none; padding:4px 0; display:flex; justify-content:space-between; gap:8px; font-size:13px }
+  #ticketsTable td::before{ content:attr(data-label); font-weight:600; color:var(--muted) }
+  #ticketsTable td .prog{ width:100% }
+}

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -338,6 +338,28 @@ body.tv-mode .section{
 }
 .del-btn:hover{ border-color:rgba(255,69,58,.6); }
 
+/* Formulário de edição de chamado */
+.edit-form{ display:grid; gap:8px; max-width:420px; }
+.edit-form .field{ display:flex; flex-direction:column; gap:4px; font-size:12px; }
+.edit-form input, .edit-form textarea{
+  background:#0f131a;
+  border:1px solid var(--card-border);
+  border-radius:10px;
+  color:var(--text);
+  padding:8px;
+}
+.edit-form textarea{ min-height:80px; resize:vertical; }
+.edit-form .actions{ display:flex; gap:8px; margin-top:8px; }
+.save-btn{
+  background:linear-gradient(180deg,var(--brand),var(--brand-strong));
+  border:0;
+  color:#fff;
+  padding:6px 12px;
+  border-radius:8px;
+  cursor:pointer;
+  font-size:12px;
+}
+
 /* Ajuste de larguras no modo TV */
 .tv-mode .tickets{ grid-column: span 5; }
 .tv-mode .charts{ grid-column: span 7; }

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -241,36 +241,36 @@ body.tv-mode .section {
 body.tv-mode .sidebar{ display:none !important; }
 
 /* a grade que contém sidebar + topo + content deve virar 1 coluna */
-body.tv-mode .app{
-  grid-template-columns: 1fr !important;  /* mata a coluna da sidebar */
-  column-gap: 0 !important;
-  width: 100vw;
-  height: 100vh;
-  max-width: none;
-}
+  body.tv-mode .app{
+    grid-template-columns: 1fr !important;  /* mata a coluna da sidebar */
+    column-gap: 0 !important;
+    width: 100%;
+    height: 100vh;
+    max-width: none;
+  }
 
 /* topo ocupa largura total e "cola" no topo */
-body.tv-mode .top.panel{
-  border-radius: 0;
-  margin: 0;
-  max-width: none;
-  width: 100vw;
-  position: sticky;
-  top: 0;
-  z-index: 5;
-}
+  body.tv-mode .top.panel{
+    border-radius: 0;
+    margin: 0;
+    max-width: none;
+    width: 100%;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  }
 
 /* conteúdo ocupa o resto da altura da tela */
-body.tv-mode .content.panel{
-  max-width: none;
-  width: 100vw;
-  padding: 16px;
-  border-radius: 0;
-  height: calc(100vh - 64px); /* ajustado via JS também p/ ficar perfeito */
-  overflow: auto;
-  box-shadow: none;
-  border: none;
-}
+  body.tv-mode .content.panel{
+    max-width: none;
+    width: 100%;
+    padding: 16px;
+    border-radius: 0;
+    height: calc(100vh - 64px); /* ajustado via JS também p/ ficar perfeito */
+    overflow: auto;
+    box-shadow: none;
+    border: none;
+  }
 
 /* opcional: as sections ficam “flush” na TV */
 body.tv-mode .section{

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -175,9 +175,6 @@
   border-color: rgba(122,162,255,.6);
 }
 
-/* donuts levemente menores, só na aba de chamados */
-.tickets-page .pie-grid{ grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; }
-.tickets-page .donut svg{ width:108px; height:108px; }
 /* Oculta o detalhe por padrão */
 #sectionTickets .ticket-detail{ display:none; }
 

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -326,5 +326,21 @@ body.tv-mode .section{
   overflow-x: hidden;  /* mata qualquer transbordo horizontal */
 }
 
+/* Botões de edição e exclusão */
+.edit-btn, .del-btn{
+  background:#12161e;
+  border:1px solid var(--card-border);
+  color:var(--text);
+  padding:4px 8px;
+  border-radius:8px;
+  cursor:pointer;
+  font-size:12px;
+}
+.del-btn:hover{ border-color:rgba(255,69,58,.6); }
+
+/* Ajuste de larguras no modo TV */
+.tv-mode .tickets{ grid-column: span 5; }
+.tv-mode .charts{ grid-column: span 7; }
+
 /* Quando sair do modo TV, não deixa "fantasma" de alturas */
 .content.panel{ min-height: 0; } /* garante que filhos possam rolar */

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -35,6 +35,12 @@
 .table tbody tr.selected{ background:#151a24; box-shadow: inset 0 0 0 1px rgba(122,162,255,.35) }
 .table tbody tr:last-child td{ border-bottom:none }
 
+/* em telas pequenas permita rolagem horizontal da tabela */
+@media (max-width: 600px){
+  .table-wrap{ overflow-x:auto; }
+  .table{ min-width:600px; }
+}
+
 .prog{ display:grid; gap:6px }
 .prog .nums{ display:flex; gap:10px; font-size:12px; color:#cbd5e1 }
 .nums b{ color:#fff }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -24,13 +24,14 @@
 @media (max-width: 1200px){ .tickets{ grid-column: span 12 } .charts{ grid-column: span 12 } }
 @media (max-width: 900px){
   .app{ grid-template-columns: 1fr; grid-template-rows: 64px auto 1fr; width:100vw; height:auto; min-height:100vh }
-  .sidebar{ position: fixed; z-index: 10; left:12px; right:12px; top:12px; bottom:12px; transform: translateY(-8px) scale(.98); opacity:0; pointer-events:none; transition: opacity var(--transition), transform var(--transition); }
+  .sidebar{ position: fixed; z-index: 10; left:12px; right:12px; top:12px; bottom:12px; transform: translateY(-8px) scale(.98); opacity:0; pointer-events:none; transition: opacity var(--transition), transform var(--transition); background:#10141c; }
   .sidebar.open{ opacity:1; transform: translateY(0) scale(1); pointer-events:auto }
   .top{ grid-column:1 }
-  .hamburger{ display:block }
+  .hamburger{ display:block; position:relative; z-index:11 }
+  .tv-mode-btn{ display:none }
   .content{ grid-column:1; grid-template-columns: repeat(6, 1fr); }
 }
-@media (max-width: 560px){ .content{ grid-template-columns: repeat(2, 1fr) } }
+@media (max-width: 560px){ .content{ grid-template-columns: 1fr } }
 
 /* Páginas/estados */
 .projects-page .tickets, .projects-page .charts{ display:none }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -23,7 +23,7 @@
 /* Responsivo */
 @media (max-width: 1200px){ .tickets{ grid-column: span 12 } .charts{ grid-column: span 12 } }
 @media (max-width: 900px){
-  .app{ grid-template-columns: 1fr; grid-template-rows: 64px auto 1fr; width:98vw; height:96vh }
+  .app{ grid-template-columns: 1fr; grid-template-rows: 64px auto 1fr; width:100vw; height:auto; min-height:100vh }
   .sidebar{ position: fixed; z-index: 10; left:12px; right:12px; top:12px; bottom:12px; transform: translateY(-8px) scale(.98); opacity:0; pointer-events:none; transition: opacity var(--transition), transform var(--transition); }
   .sidebar.open{ opacity:1; transform: translateY(0) scale(1); pointer-events:auto }
   .top{ grid-column:1 }

--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -21,3 +21,8 @@ form.visible{ display:block; opacity:1; transform: translateY(0) }
 .input{ width:100%; padding:12px 14px; color:var(--text); background: #0f131a; border:1px solid var(--card-border); border-radius: 12px; }
 .continue{ margin-top:18px; width:100%; padding:12px 16px; border-radius:12px; border:0; cursor:not-allowed; background: #1a1f2a; color:#9ba3af; }
 .continue.enabled{ cursor:pointer; background: linear-gradient(180deg, var(--brand), var(--brand-strong)); color:#fff }
+
+/* Em telas pequenas o card precisa de margem para rolar */
+@media (max-width: 900px){
+  .card{ margin:40px auto; }
+}

--- a/db.json
+++ b/db.json
@@ -1,0 +1,34 @@
+{
+  "tickets": [
+    { "id":"CH-1021", "createdAt":"2025-08-06T09:35:00", "meetPoint":"Centro - Loja 12", "dupla":"Ana & João", "concl":62, "prazo":45, "resumo":"Queda intermitente na rede local.", "solicitante":"Carlos M.", "telefone":"(21) 90000-1021", "descricao":"Queda intermitente na rede local. Equipamentos reiniciam sem aviso, requer verificação detalhada." },
+    { "id":"CH-1022", "createdAt":"2025-08-06T14:10:00", "meetPoint":"Zona Sul - Posto 3", "dupla":"Marcos & Lia", "concl":35, "prazo":22, "resumo":"Atualização de firmware pendente.", "solicitante":"Júlia P.", "telefone":"(21) 90000-1022", "descricao":"Atualização de firmware pendente em vários roteadores da filial." },
+    { "id":"CH-1023", "createdAt":"2025-08-07T18:55:00", "meetPoint":"Barra - Quiosque B", "dupla":"Rafa & Gui", "concl":88, "prazo":76, "resumo":"Troca de ONU e reconfiguração.", "solicitante":"Ricardo L.", "telefone":"(21) 90000-1023", "descricao":"Troca de ONU e reconfiguração completa do enlace principal." },
+    { "id":"CH-1024", "createdAt":"2025-08-07T07:20:00", "meetPoint":"Centro - Praça 7", "dupla":"Paula & Leo", "concl":20, "prazo":12, "resumo":"Visita inicial, aguardando acesso.", "solicitante":"Mariana S.", "telefone":"(21) 90000-1024", "descricao":"Visita inicial, aguardando acesso ao edifício para diagnóstico." },
+    { "id":"CH-1025", "createdAt":"2025-08-08T11:45:00", "meetPoint":"Niterói - Estação", "dupla":"Bia & Tom", "concl":58, "prazo":40, "resumo":"Ajuste de alinhamento de antena.", "solicitante":"Eduardo T.", "telefone":"(21) 90000-1025", "descricao":"Ajuste de alinhamento de antena para melhora de sinal." },
+    { "id":"CH-1026", "createdAt":"2025-08-08T12:30:00", "meetPoint":"Copacabana - Posto 5", "dupla":"Vivi & Dan", "concl":12, "prazo":8, "resumo":"Inspeção de cabeamento.", "solicitante":"Fernanda B.", "telefone":"(21) 90000-1026", "descricao":"Inspeção de cabeamento em rede interna do cliente." },
+    { "id":"CH-1027", "createdAt":"2025-08-08T13:05:00", "meetPoint":"Tijuca - Saens Peña", "dupla":"Caio & Nina", "concl":42, "prazo":51, "resumo":"Oscilação de potência no enlace.", "solicitante":"Sérgio A.", "telefone":"(21) 90000-1027", "descricao":"Oscilação de potência no enlace precisa de análise de interferência." },
+    { "id":"CH-1028", "createdAt":"2025-08-08T13:50:00", "meetPoint":"Centro - Ed. Rio", "dupla":"Leo & Tati", "concl":74, "prazo":60, "resumo":"Revisão de configuração de roteador.", "solicitante":"Patrícia F.", "telefone":"(21) 90000-1028", "descricao":"Revisão de configuração de roteador e otimização de QoS." },
+    { "id":"CH-1029", "createdAt":"2025-08-08T14:25:00", "meetPoint":"Ilha - Galeão", "dupla":"Iuri & Fê", "concl":28, "prazo":30, "resumo":"Troca de patch cords danificados.", "solicitante":"Henrique C.", "telefone":"(21) 90000-1029", "descricao":"Troca de patch cords danificados e testes de continuidade." },
+    { "id":"CH-1030", "createdAt":"2025-08-08T15:10:00", "meetPoint":"Barra - Shopping X", "dupla":"Gabi & Renan", "concl":91, "prazo":85, "resumo":"Homologação final do link.", "solicitante":"Bianca R.", "telefone":"(21) 90000-1030", "descricao":"Homologação final do link com validação de performance." }
+  ],
+  "projects": [
+    { "id":"PR-2001", "name":"Integração CRM", "desc":"Conectar pipeline de vendas ao painel.", "prazo":"2025-09-15", "dias":40, "pessoas":5, "diasTrab":22, "pct":55 },
+    { "id":"PR-2002", "name":"App Mobile Field", "desc":"Aplicativo de campo para equipes externas.", "prazo":"2025-10-02", "dias":55, "pessoas":7, "diasTrab":18, "pct":32 },
+    { "id":"PR-2003", "name":"Relatórios V2", "desc":"Dashboards executivos e exportações.", "prazo":"2025-08-30", "dias":20, "pessoas":3, "diasTrab":12, "pct":70 },
+    { "id":"PR-2004", "name":"Onboarding Rápido", "desc":"Fluxo simplificado para novos clientes.", "prazo":"2025-09-05", "dias":18, "pessoas":2, "diasTrab":9, "pct":48 },
+    { "id":"PR-2005", "name":"Chatbot L2", "desc":"Bot de triagem de chamados nível 2.", "prazo":"2025-11-01", "dias":60, "pessoas":6, "diasTrab":10, "pct":20 },
+    { "id":"PR-2006", "name":"Portal Parceiros", "desc":"Área para parceiros externos.", "prazo":"2025-12-15", "dias":75, "pessoas":8, "diasTrab":15, "pct":26 }
+  ],
+  "materialsByProject": {
+    "PR-2001": ["API Key CRM","Webhook /lead-created","Tabela staging_crm","Doc mapeamento campos"],
+    "PR-2002": ["Design Figma Mobile","SDK Camera","GPS Provider","Guia de acessibilidade"],
+    "PR-2003": ["Spec KPIs","Lib export CSV","Template PDF","Exemplos de queries"],
+    "PR-2004": ["Flowchart onboarding","Email templates","Checklist CS"],
+    "PR-2005": ["Dataset intents L2","NLP model v0.9","Playbook fallback"],
+    "PR-2006": ["Contrato parceiro","Guia branding","Endpoint /partners"]
+  },
+  "rdosByTicket": {
+    "CH-1021": ["RDO 08/06 - inspeção inicial","RDO 08/07 - ajuste de parâmetros"],
+    "CH-1023": ["RDO 08/07 - troca de ONU","RDO 08/08 - testes finais"]
+  }
+}


### PR DESCRIPTION
## Summary
- Consolidate TV mode toggle logic to resize content and re-render dashboard sections
- Prevent horizontal overflow in TV mode by using percentage widths
- Ensure ticket summary column and expanded project details only appear in TV mode

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_68969f98578c8330acd3d5ce0528e546