### PR TITLE
feat: manage create page layout

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -199,6 +199,37 @@
   display:grid !important; /* grid p/ manter o layout do header/meta/tabs */
 }
 
+/* === Detalhe: Descrição mais legível === */
+#tdDesc{
+  padding-top: 6px;
+}
+
+.td-desc{
+  background: #0b0f16;
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+  white-space: pre-wrap;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+.td-desc h4{
+  margin: 2px 0 4px;
+  font-size: 13px;
+  color: var(--muted);
+  letter-spacing: .2px;
+}
+
+.td-desc p{ margin:0; }
+.td-desc ul, .td-desc ol{ margin-left:18px; display:grid; gap:4px; }
+.td-desc .divider{
+  height:1px; background:var(--card-border);
+  margin:2px 0;
+}
+
 /* ===== Finished Projects page layout ===== */
 /* deixa a página 100% alta e a seção rolar por dentro */
 .finished-projects-page .content{
@@ -245,19 +276,7 @@
   gap: 8px;
 }
 
-/* Botão TV */
-.tv-mode-btn {
-  background: #12161e;
-  border: 1px solid var(--card-border);
-  color: var(--text);
-  padding: 6px 10px;
-  border-radius: 8px;
-  cursor: pointer;
-  margin-right: 8px;
-}
-.tv-mode-btn:hover {
-  border-color: rgba(122,162,255,.45);
-}
+.top-actions .btn + .btn{ margin-left:6px; }
 
 /* Layout em tela cheia (modo TV) */
 body.tv-mode .sidebar {

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -527,3 +527,32 @@ body.tv-mode .section{
   border: 2px solid rgba(255,255,255,.06);
 }
 
+/* ====== CREATE PAGES: faz a seção preencher o painel ====== */
+.create-page .content{
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* as seções de criação ocupam todo o espaço disponível */
+.create-page #sectionCreateTicket,
+.create-page #sectionCreateProject{
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* o formulário rola por dentro do bloco #10141c */
+.create-page #sectionCreateTicket .edit-form,
+.create-page #sectionCreateProject .edit-form{
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+/* garante que filhos possam rolar (você já tem, mas reforço) */
+.content.panel{ min-height: 0; }
+

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -198,6 +198,41 @@
 .tickets-page #sectionTickets .ticket-detail{
   display:grid !important; /* grid p/ manter o layout do header/meta/tabs */
 }
+
+/* ===== Finished Projects page layout ===== */
+/* deixa a página 100% alta e a seção rolar por dentro */
+.finished-projects-page .content{
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* a seção ocupa o resto do painel e não corta conteúdo */
+.finished-projects-page #sectionFinishedProjects{
+  display: flex;      /* vira um container vertical */
+  flex: 1;            /* preenche a altura */
+  min-height: 0;      /* permite overflow interno */
+  overflow: hidden;   /* quem rola é a .table-wrap */
+  grid-column: 1 / -1;
+}
+
+/* tabela rola sem “cortar” nada */
+.finished-projects-page #sectionFinishedProjects .table-wrap{
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  max-height: none;   /* remove teto que podia cortar */
+}
+
+/* em mobile, manter rolagem horizontal se precisar */
+@media (max-width: 600px){
+  .finished-projects-page #sectionFinishedProjects .table{
+    min-width: 600px;
+  }
+}
+
 /* Topo da dashboard */
 .top {
   display: flex;
@@ -342,17 +377,29 @@ body.tv-mode .section{
   overflow-x: hidden;  /* mata qualquer transbordo horizontal */
 }
 
-/* Botões de edição e exclusão */
-.edit-btn, .del-btn{
-  background:#12161e;
-  border:1px solid var(--card-border);
-  color:var(--text);
-  padding:4px 8px;
-  border-radius:8px;
-  cursor:pointer;
-  font-size:12px;
+/* === Botões utilitários (harmonizados) === */
+.btn{ background:#141820; color:var(--text); border:1px solid var(--card-border); padding: 10px 12px; border-radius:10px; cursor:pointer; transition: transform var(--transition), border-color var(--transition), background var(--transition), opacity var(--transition); font-size:13px; line-height:1; }
+.btn:hover{ transform: translateY(-1px); border-color: rgba(122,162,255,.45); }
+.btn:disabled{ opacity:.6; cursor:not-allowed; }
+
+.btn-primary{ background: linear-gradient(180deg, var(--brand), var(--brand-strong)); border-color: transparent; color:#fff; font-weight:600; }
+.btn-outline{ background:#12161e; border:1px solid var(--card-border); color:var(--text); }
+.btn-ghost{ background: transparent; border:1px dashed rgba(255,255,255,.18); color:#cbd5e1; }
+.btn-danger{ background:#161218; border:1px solid rgba(255,69,58,.45); color:#fecaca; }
+.btn-danger:hover{ border-color: rgba(255,69,58,.7); }
+
+.btn-sm{ padding:6px 10px; font-size:12px; border-radius:8px; }
+
+.actions-cell{
+  display:flex;
+  align-items:center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
-.del-btn:hover{ border-color:rgba(255,69,58,.6); }
+
+/* compatibilidade com nomes antigos */
+.edit-btn{ composes: btn btn-outline btn-sm; }
+.del-btn{ composes: btn btn-danger btn-sm; }
 
 /* Formulário de edição de chamado */
 .edit-form{ display:grid; gap:8px; max-width:420px; }
@@ -366,15 +413,6 @@ body.tv-mode .section{
 }
 .edit-form textarea{ min-height:80px; resize:vertical; }
 .edit-form .actions{ display:flex; gap:8px; margin-top:8px; }
-.save-btn{
-  background:linear-gradient(180deg,var(--brand),var(--brand-strong));
-  border:0;
-  color:#fff;
-  padding:6px 12px;
-  border-radius:8px;
-  cursor:pointer;
-  font-size:12px;
-}
 
 /* Ajuste de larguras no modo TV */
 .tv-mode .tickets{ grid-column: span 5; }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -31,7 +31,6 @@
   .sidebar.open{ opacity:1; transform: translateY(0) scale(1); pointer-events:auto }
   .top{ grid-column:1 }
   .hamburger{ display:block; position:relative; z-index:11 }
-  .tv-mode-btn{ display:none }
   .content{ grid-column:1; grid-template-columns: repeat(6, 1fr); }
 }
 @media (max-width: 560px){ .content{ grid-template-columns: 1fr } }

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -1,0 +1,71 @@
+/* ===== MOBILE SHELL ===== */
+.is-mobile .app{
+  width: 100vw; height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 56px 1fr 56px;
+  gap: 8px;
+  padding: 8px;
+}
+
+.is-mobile .sidebar{ display: none !important; }
+.is-mobile .top.panel{ border-radius: 10px; }
+.is-mobile .content.panel{
+  padding: 8px;
+  height: auto;
+  overflow: auto;
+}
+
+/* Seções mais compactas */
+.is-mobile .section{ border-radius: 10px; padding: 10px; }
+
+/* Esconde gráficos no mobile (caso o template desktop seja carregado por engano) */
+.is-mobile #sectionCharts{ display: none !important; }
+
+/* Bottom nav */
+.is-mobile .bottom-nav{
+  position: fixed; left: 8px; right: 8px; bottom: 8px;
+  display: flex; gap: 8px; justify-content: space-between;
+  background: var(--surface);
+  border: 1px solid var(--card-border);
+  border-radius: 12px; padding: 8px;
+}
+.is-mobile .bn-btn{
+  flex: 1;
+  padding: 10px 6px;
+  border-radius: 10px;
+  border: 1px solid var(--card-border);
+  background: #12161e;
+  color: var(--text);
+  font-size: 13px;
+}
+.is-mobile .bn-btn.active{
+  border-color: rgba(122,162,255,.6);
+  box-shadow: 0 0 0 4px rgba(122,162,255,.12) inset;
+}
+
+/* Tabelas em cartões (reforço do seu CSS responsivo) */
+.is-mobile #ticketsTable tr{ padding: 10px; }
+
+/* Admin submenu overlay */
+.is-mobile .admin-subnav{
+  position: fixed;
+  bottom: 72px;
+  left: 8px; right: 8px;
+  display: none;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--surface);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 8px;
+}
+.is-mobile .admin-subnav.open{ display: flex; }
+.is-mobile .admin-subnav .navbtn{
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: #12161e;
+  color: var(--text);
+  text-align: left;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -221,7 +221,7 @@
         hideAllSections();
         setPageState('default');
 
-        document.body.classList.remove('projects-page','tickets-page');
+        document.body.classList.remove('projects-page','tickets-page','finished-projects-page');
         if (which === 'projects') document.body.classList.add('projects-page');
         if (which === 'tickets')  document.body.classList.add('tickets-page');
 
@@ -397,7 +397,7 @@
             <td data-label="% de prazo">
               <div class="prog ${prazoClass}"><div class="nums"><span>Prazo: <b>${prazoPct}%</b></span></div><div class="progress"><i style="width:${Math.min(prazoPct,100)}%"></i></div></div>
             </td>
-            <td data-label="Ações"><button class="restore" data-id="${t.id}">Desarquivar</button> <button class="delete" data-id="${t.id}">Excluir</button></td>
+            <td class="actions-cell"><button class="restore btn btn-outline btn-sm" data-id="${t.id}">Restaurar</button> <button class="delete btn btn-danger btn-sm" data-id="${t.id}">Excluir</button></td>
           `;
           els.archivedTicketsBody.appendChild(tr);
         });
@@ -430,7 +430,7 @@
             <td data-label="% de prazo">
               <div class="prog ${prazoClass}"><div class="nums"><span>Prazo: <b>${prazoPct}%</b></span></div><div class="progress"><i style="width:${Math.min(prazoPct,100)}%"></i></div></div>
             </td>
-            <td data-label="Ações"><button class="restore" data-id="${t.id}">Desarquivar</button> <button class="delete" data-id="${t.id}">Excluir</button></td>
+            <td class="actions-cell"><button class="restore btn btn-outline btn-sm" data-id="${t.id}">Restaurar</button> <button class="delete btn btn-danger btn-sm" data-id="${t.id}">Excluir</button></td>
           `;
           els.finishedTicketsBody.appendChild(tr);
         });
@@ -453,7 +453,7 @@
             <td data-label="ID">${p.id}</td>
             <td data-label="Nome">${p.name}</td>
             <td data-label="Prazo">${parseDateLocal(p.prazo).toLocaleDateString('pt-BR')}</td>
-            <td data-label="Ações"><button class="restore" data-id="${p.id}">Desarquivar</button> <button class="delete" data-id="${p.id}">Excluir</button></td>
+            <td class="actions-cell"><button class="restore btn btn-outline btn-sm" data-id="${p.id}">Restaurar</button> <button class="delete btn btn-danger btn-sm" data-id="${p.id}">Excluir</button></td>
           `;
           els.archivedProjectsBody.appendChild(tr);
         });
@@ -476,7 +476,7 @@
             <td data-label="ID">${p.id}</td>
             <td data-label="Nome">${p.name}</td>
             <td data-label="Prazo">${parseDateLocal(p.prazo).toLocaleDateString('pt-BR')}</td>
-            <td data-label="Ações"><button class="restore" data-id="${p.id}">Desarquivar</button> <button class="delete" data-id="${p.id}">Excluir</button></td>
+            <td class="actions-cell"><button class="restore btn btn-outline btn-sm" data-id="${p.id}">Restaurar</button> <button class="delete btn btn-danger btn-sm" data-id="${p.id}">Excluir</button></td>
           `;
           els.finishedProjectsBody.appendChild(tr);
         });
@@ -494,7 +494,7 @@
         hideAllSections();
         show('#sectionCreateTicket');
         setPageState('create-ticket');
-        document.body.classList.remove('tickets-page','projects-page');
+        document.body.classList.remove('tickets-page','projects-page','finished-projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Criar chamado';
 
         // garante que o painel entre em cena com scroll e foco
@@ -617,7 +617,7 @@
         hideAllSections();
         show('#sectionCreateProject');
         setPageState('create-project');
-        document.body.classList.remove('tickets-page','projects-page');
+        document.body.classList.remove('tickets-page','projects-page','finished-projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Criar projeto';
 
         requestAnimationFrame(()=>{
@@ -716,7 +716,7 @@
         show('#sectionArchivedTickets');
         setPageState('default');
         document.body.classList.add('tickets-page');
-        document.body.classList.remove('projects-page');
+        document.body.classList.remove('projects-page','finished-projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Chamados arquivados';
         this.renderArchivedTickets();
       },
@@ -725,7 +725,7 @@
         show('#sectionFinishedTickets');
         setPageState('default');
         document.body.classList.add('tickets-page');
-        document.body.classList.remove('projects-page');
+        document.body.classList.remove('projects-page','finished-projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Chamados finalizados';
         this.renderFinishedTickets();
       },
@@ -734,18 +734,9 @@
         show('#sectionArchivedProjects');
         setPageState('default');
         document.body.classList.add('projects-page');
-        document.body.classList.remove('tickets-page');
+        document.body.classList.remove('tickets-page','finished-projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Projetos arquivados';
         this.renderArchivedProjects();
-      },
-      showFinishedProjects(){
-        hideAllSections();
-        show('#sectionFinishedProjects');
-        setPageState('default');
-        document.body.classList.add('projects-page');
-        document.body.classList.remove('tickets-page');
-        if (els.sectionPill) els.sectionPill.textContent = 'Projetos finalizados';
-        this.renderFinishedProjects();
       },
 
       // *** ainda dentro de UI ***
@@ -879,23 +870,27 @@
 
           const actions = document.createElement('div');
           actions.className = 'actions';
+          const btnCancel = document.createElement('button');
+          btnCancel.type = 'button';
+          btnCancel.className = 'btn btn-outline btn-sm';
+          btnCancel.id = 'btnCancelEdit';
+          btnCancel.textContent = 'Cancelar';
           const btnSave = document.createElement('button');
           btnSave.type = 'submit';
-          btnSave.className = 'btn btn-primary';
-          btnSave.textContent = 'Salvar';
+          btnSave.className = 'btn btn-primary btn-sm';
+          btnSave.id = 'btnSaveEdit';
+          btnSave.textContent = 'Salvar alterações';
           const btnArchive = document.createElement('button');
           btnArchive.type = 'button';
-          btnArchive.className = 'btn';
+          btnArchive.className = 'btn btn-ghost btn-sm';
           btnArchive.id = 'btnArchiveTicket';
           btnArchive.textContent = 'Arquivar';
           const btnDel = document.createElement('button');
           btnDel.type = 'button';
-          btnDel.className = 'del-btn btn';
+          btnDel.className = 'btn btn-danger btn-sm';
           btnDel.id = 'btnDelTicket';
           btnDel.textContent = 'Excluir';
-          actions.appendChild(btnSave);
-          actions.appendChild(btnArchive);
-          actions.appendChild(btnDel);
+          actions.append(btnCancel, btnSave, btnArchive, btnDel);
           form.appendChild(actions);
           els.tdEditForm.appendChild(form);
 
@@ -908,6 +903,7 @@
             updated.concl = Number(updated.concl || 0);
             UI.editTicket(t, updated);
           });
+          btnCancel.addEventListener('click', ()=> UI.openTicketDetail(t));
           btnArchive.addEventListener('click', ()=> UI.archiveTicket(t));
           btnDel.addEventListener('click', ()=> UI.deleteTicket(t));
         }
@@ -1323,7 +1319,13 @@
       els.sidebar?.classList.remove('open');
     });
     els.btnAdminFinishedProjects?.addEventListener('click', ()=>{
-      UI.showFinishedProjects();
+      hideAllSections();
+      if (els.sectionFinishedProjects) els.sectionFinishedProjects.style.display = 'block';
+      setPageState('default');
+      document.body.classList.remove('tickets-page','projects-page','create-page','create-ticket-page','create-project-page','finished-projects-page');
+      document.body.classList.add('finished-projects-page');
+      if (els.sectionPill) els.sectionPill.textContent = 'Projetos finalizados';
+      UI.renderFinishedProjects();
       els.adminMenu?.classList.remove('open');
       els.sidebar?.classList.remove('open');
     });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,17 +1,33 @@
 (function(){
+  let adminMenuOpen = false;
+
+  function detectMobile(){
+    const params = new URLSearchParams(location.search);
+    const force = params.get('mobile') ?? localStorage.getItem('forceMobile');
+    if (force === '1') return true;
+    if (force === '0') return false;
+    const isTouch = ('ontouchstart' in window) || navigator.maxTouchPoints > 0;
+    const isNarrow = window.matchMedia('(max-width: 900px)').matches;
+    return isTouch && isNarrow;
+  }
+  let IS_MOBILE = detectMobile();
+  document.body.classList.toggle('is-mobile', IS_MOBILE);
+
+  function renderShell(){
+    const loginView = qs('#view-login');
+    const dashView = qs('#view-dashboard');
+    if (loginView) loginView.innerHTML = IS_MOBILE && tpl.loginMobile ? tpl.loginMobile() : tpl.login();
+    if (dashView){
+      dashView.style.display = 'none';
+      dashView.innerHTML = IS_MOBILE && tpl.dashboardMobile ? tpl.dashboardMobile() : tpl.dashboard();
+    }
+    document.body.classList.toggle('is-mobile', IS_MOBILE);
+  }
+
   // App principal: fluxo de login, carregamento de dados e dashboard
   // ========== BOOT ==========
   document.addEventListener('DOMContentLoaded', () => {
-    const loginView = qs('#view-login');
-    const dashView = qs('#view-dashboard');
-
-    // Sempre injeta os templates para garantir a árvore esperada
-    if (loginView) loginView.innerHTML = tpl.login();
-    if (dashView) {
-      dashView.style.display = 'none';
-      dashView.innerHTML = tpl.dashboard(); // <— força injeção
-    }
-
+    renderShell();
     bindLogin();
   });
 
@@ -429,7 +445,7 @@
     };
 
     const adminMenu = els.adminMenu;
-    let adminMenuOpen = adminMenu?.classList.contains('open') || false;
+    adminMenuOpen = adminMenu?.classList.contains('open') || adminMenuOpen;
 
     // Oculta itens de admin para usuários comuns
     if (CURRENT_ROLE !== 'admin') {
@@ -498,6 +514,7 @@
       },
 
       _renderOverview(){
+        if (IS_MOBILE) return;
         const t = this._selected || DB.state.tickets[0];
         if (!t) return;
         const p = computeDeadlinePct(t.createdAt, t.dueDate);
@@ -1004,7 +1021,7 @@
         if(this._selectedRow){ this._selectedRow.classList.remove('selected'); }
         if(rowEl){ rowEl.classList.add('selected'); this._selectedRow = rowEl; }
         const p = computeDeadlinePct(t.createdAt, t.dueDate);
-        this.renderSLAChart(t.concl, Math.min(p,100));
+        if (!IS_MOBILE) this.renderSLAChart(t.concl, Math.min(p,100));
       },
 
       openTicketDetail(t, rowEl){
@@ -1559,10 +1576,48 @@
       adminMenu?.classList.toggle('open', adminMenuOpen);
     });
 
+    if (IS_MOBILE){
+      document.querySelectorAll('.bottom-nav .bn-btn').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          document.querySelectorAll('.bottom-nav .bn-btn').forEach(b=>b.classList.remove('active'));
+          btn.classList.add('active');
+          const tab = btn.dataset.tab;
+          if (tab === 'overview') {
+            UI.setActiveTab('overview');
+          } else if (tab === 'tickets') {
+            UI.setActiveTab('tickets');
+            const firstTicket = DB.state.tickets?.[0];
+            const firstRow = document.querySelector('#ticketsTable tbody tr');
+            if (firstTicket && firstRow){
+              UI.openTicketDetail(firstTicket, firstRow);
+            } else {
+              const det = document.getElementById('ticketDetail');
+              if (det) det.style.display = 'none';
+            }
+          } else if (tab === 'projects') {
+            UI.setActiveTab('projects');
+            const first = DB.state.projects?.[0];
+            if (first){
+              UI.openProjectDetailInline(first);
+              document.querySelectorAll('#projectsCarousel .project.selected').forEach(el=>el.classList.remove('selected'));
+              const firstCard = document.querySelector('#projectsCarousel .project');
+              firstCard?.classList.add('selected');
+            }
+          } else if (tab === 'admin') {
+            adminMenuOpen = !adminMenuOpen;
+            adminMenu?.classList.toggle('open', adminMenuOpen);
+          }
+        });
+      });
+    }
+
     // Boot inicial
     UI.setActiveTab('overview');
     UI.renderAll();
     UI.selectTicket(DB.state.tickets[0]);
+    if (IS_MOBILE){
+      document.querySelector('.bottom-nav .bn-btn[data-tab="overview"]')?.classList.add('active');
+    }
 
     // Debug opcional: veja o que existe na DOM
     // console.table(Object.fromEntries(Object.entries(els).map(([k,v])=>[k, !!v])));

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -143,6 +143,40 @@
     return Math.max(0, pct);
   }
 
+  // ===== Observações: utils =====
+  function isAdminUser(){
+    return CURRENT_ROLE === 'admin';
+  }
+
+  function esc(s){
+    return String(s ?? '')
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;')
+      .replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  }
+
+  function ensureObsArray(ticket){
+    if (!ticket.observacoes) {
+      ticket.observacoes = ticket.obs || [];
+      delete ticket.obs;
+    }
+    if (typeof ticket.observacoes === 'string'){
+      ticket.observacoes = [{ id: Date.now(), texto: ticket.observacoes, autor: 'sistema', criadoEm: new Date() }];
+    }
+    if (!Array.isArray(ticket.observacoes)){
+      ticket.observacoes = [ticket.observacoes];
+    }
+    ticket.observacoes = ticket.observacoes.map((o,i) => ({
+      id: o?.id ?? (Date.now()+i),
+      texto: String(o?.texto ?? o?.text ?? o ?? ''),
+      autor: o?.autor ?? o?.author ?? '—',
+      criadoEm: o?.criadoEm ?? o?.createdAt ?? new Date(),
+    }));
+  }
+
+  function findTicketById(id){
+    return window.DATA?.tickets?.find(t => String(t.id) === String(id)) || null;
+  }
+
   // Controla classes do <body> conforme a página
   function setPageState(state){
     document.body.classList.remove('create-page','create-ticket-page','create-project-page');
@@ -169,6 +203,95 @@
       const el = document.getElementById(id);
       if (el) el.style.display = 'none';
     });
+  }
+
+  function renderObservacoes(ticket){
+    ensureObsArray(ticket);
+    const admin = isAdminUser();
+    const panel = document.getElementById('tdObs');
+    if (!panel) return;
+
+    const items = ticket.observacoes;
+    const listHtml = items.length ? `
+      <ul id="tdObsList" style="display:grid; gap:8px; margin-left:18px">
+        ${items.map(o => `
+          <li data-id="${o.id}" style="display:flex; gap:8px; align-items:flex-start">
+            <div style="flex:1">
+              <div style="font-size:13px; color:#cbd5e1">${esc(o.texto)}</div>
+              <small style="color:#9aa0a6">${esc(o.autor)} • ${new Date(o.criadoEm).toLocaleDateString()}</small>
+            </div>
+            ${admin ? `
+              <div class="actions-cell">
+                <button class="btn btn-outline btn-sm" data-act="edit">Editar</button>
+                <button class="btn btn-danger  btn-sm" data-act="del">Excluir</button>
+              </div>
+            ` : ``}
+          </li>
+        `).join('')}
+      </ul>
+    ` : `
+      <div id="tdObsList"></div>
+    `;
+
+    const formHtml = admin ? `
+      <div id="tdObsForm" style="margin-top:10px">
+        <textarea id="tdObsInput" style="width:100%; min-height:100px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Adicionar observação..."></textarea>
+        <div class="actions" style="margin-top:6px">
+          <button type="button" class="btn btn-primary btn-sm" id="tdObsAdd">Adicionar</button>
+        </div>
+      </div>
+    ` : ``;
+
+    panel.innerHTML = listHtml + formHtml;
+
+    if (admin){
+      const addBtn = document.getElementById('tdObsAdd');
+      addBtn?.addEventListener('click', () => {
+        const ta = document.getElementById('tdObsInput');
+        const txt = (ta?.value || '').trim();
+        if (!txt) return;
+        ticket.observacoes.push({
+          id: Date.now(),
+          texto: txt,
+          autor: CURRENT_USER || 'admin',
+          criadoEm: new Date()
+        });
+        renderObservacoes(ticket);
+      });
+
+      document.getElementById('tdObs')?.addEventListener('click', (e) => {
+        const btn = e.target.closest('button[data-act]');
+        if (!btn) return;
+        const li = btn.closest('li[data-id]');
+        if (!li) return;
+        const id = li.getAttribute('data-id');
+        const idx = ticket.observacoes.findIndex(o => String(o.id) === String(id));
+        if (idx < 0) return;
+
+        if (btn.dataset.act === 'del'){
+          ticket.observacoes.splice(idx, 1);
+          renderObservacoes(ticket);
+        } else if (btn.dataset.act === 'edit'){
+          const o = ticket.observacoes[idx];
+          li.innerHTML = `
+            <div style="flex:1; display:grid; gap:6px">
+              <textarea class="obs-edit" style="width:100%; min-height:100px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px">${esc(o.texto)}</textarea>
+              <small style="color:#9aa0a6">${esc(o.autor)} • ${new Date(o.criadoEm).toLocaleDateString()}</small>
+            </div>
+            <div class="actions-cell">
+              <button class="btn btn-outline btn-sm" data-act="cancel">Cancelar</button>
+              <button class="btn btn-primary btn-sm" data-act="save">Salvar</button>
+            </div>
+          `;
+          li.querySelector('[data-act="cancel"]').addEventListener('click', () => renderObservacoes(ticket));
+          li.querySelector('[data-act="save"]').addEventListener('click', () => {
+            const nv = li.querySelector('.obs-edit').value.trim();
+            ticket.observacoes[idx].texto = nv;
+            renderObservacoes(ticket);
+          });
+        }
+      }, { once: true });
+    }
   }
 
   // ========== DASHBOARD ==========
@@ -219,6 +342,9 @@
       _subtabsBound: false,
     };
 
+    const adminMenu = els.adminMenu;
+    let adminMenuOpen = adminMenu?.classList.contains('open') || false;
+
     // Oculta itens de admin para usuários comuns
     if (CURRENT_ROLE !== 'admin') {
       if (els.tabConfig) els.tabConfig.style.display = 'none';
@@ -248,6 +374,7 @@
         [els.tabOverview, els.tabTickets, els.tabProjects].forEach(b=> b?.classList.remove('active'));
         hideAllSections();
         setPageState('default');
+        adminMenu?.classList.toggle('open', adminMenuOpen);
 
         document.body.classList.remove('projects-page','tickets-page','finished-projects-page');
         if (which === 'projects') document.body.classList.add('projects-page');
@@ -404,6 +531,13 @@
           el.addEventListener('click', ()=> UI.openProjectDetailInline(p));
         els.projectsCarousel.appendChild(el);
       });
+
+        if (document.body.classList.contains('projects-page') && DB.state.projects.length){
+          UI.openProjectDetailInline(DB.state.projects[0]);
+          document.querySelectorAll('#projectsCarousel .project.selected').forEach(el=>el.classList.remove('selected'));
+          const firstCard = els.projectsCarousel.querySelector('.project');
+          firstCard?.classList.add('selected');
+        }
       },
 
       renderArchivedTickets(){
@@ -623,8 +757,10 @@
               form.reset();
               ui.renderTickets();
               ui.setActiveTab('tickets');
-              els.adminMenu?.classList.remove('open');
-              els.sidebar?.classList.remove('open');
+              adminMenu?.classList.toggle('open', adminMenuOpen);
+              const ft = DB.state.tickets?.[0];
+              const fr = document.querySelector('#ticketsTable tbody tr');
+              if (ft && fr) UI.openTicketDetail(ft, fr);
             }catch(e){
               alert(e.message || 'Erro ao salvar chamado');
             }
@@ -723,6 +859,13 @@
               ui.renderProjects();
               ui.updateProjectArrows();
               ui.setActiveTab('projects');
+              const fp = DB.state.projects?.[0];
+              if (fp){
+                UI.openProjectDetailInline(fp);
+                document.querySelectorAll('#projectsCarousel .project.selected').forEach(el=>el.classList.remove('selected'));
+                const firstCard = document.querySelector('#projectsCarousel .project');
+                firstCard?.classList.add('selected');
+              }
             }catch(e){
               alert(e.message || 'Erro ao salvar projeto');
             }
@@ -813,13 +956,10 @@
             <h4>Descrição</h4>
             <p>${t.descricao}</p>
           ` : '';
-          const observ = t.obs ? `
-            <div class="divider"></div>
-            <h4>Observações</h4>
-            <p>${t.obs}</p>
-          ` : '';
-          els.tdDesc.innerHTML = `<div class="td-desc">${resumo}${descricao}${observ}</div>`;
+          els.tdDesc.innerHTML = `<div class="td-desc">${resumo}${descricao}</div>`;
         }
+
+        renderObservacoes(t);
 
         if (els.tdNotes) {
           const listEl = qs('#tdNotesList', els.tdNotes);
@@ -839,21 +979,6 @@
           }
         }
 
-        if (els.tdObs) {
-          const obs = t.obs || {};
-          if (CURRENT_ROLE === 'admin') {
-            els.tdObs.innerHTML = `<form id="tdObsForm"><textarea style="width:100%; min-height:120px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Observações gerais..." autocomplete="off">${obs.text||''}</textarea><div class="actions" style="margin-top:6px"><button type="submit" class="btn btn-primary">Salvar</button></div></form>`;
-            const form = qs('#tdObsForm', els.tdObs);
-            form.addEventListener('submit', ev=>{
-              ev.preventDefault();
-              const text = qs('textarea', form).value.trim();
-              UI.saveTicketObs(t, text);
-            });
-          } else {
-            const content = obs.text ? `<p>${obs.text}${obs.user ? `<br><small>por ${obs.user}</small>` : ''}</p>` : '<p>Nenhuma observação.</p>';
-            els.tdObs.innerHTML = content;
-          }
-        }
 
         const list = DB.state.rdosByTicket[t.id] || [];
         if (els.tdRDOList) els.tdRDOList.innerHTML = list.map(i=>`<li>${i}</li>`).join('') || '<li>Nenhum RDO registrado.</li>';
@@ -989,12 +1114,6 @@
 
       async addTicketNote(t, text){
         await DB.addTicketNote(t.id, text, CURRENT_USER);
-        UI.openTicketDetail(t);
-      },
-
-      async saveTicketObs(t, text){
-        if (CURRENT_ROLE !== 'admin') return;
-        await DB.setTicketObs(t.id, text, CURRENT_USER);
         UI.openTicketDetail(t);
       },
 
@@ -1331,38 +1450,61 @@
     els.projectsCarousel?.addEventListener('scroll', ()=> UI.updateProjectArrows());
 
     els.tabOverview?.addEventListener('click', ()=> UI.setActiveTab('overview'));
-    els.tabTickets?.addEventListener('click', ()=> UI.setActiveTab('tickets'));
-    els.tabProjects?.addEventListener('click', ()=> UI.setActiveTab('projects'));
-    els.tabAdmin?.addEventListener('click', ()=> {
+    els.tabTickets?.addEventListener('click', ()=> {
+      UI.setActiveTab('tickets');
+      const firstTicket = DB.state.tickets?.[0];
+      const firstRow = document.querySelector('#ticketsTable tbody tr');
+      if (firstTicket && firstRow){
+        UI.openTicketDetail(firstTicket, firstRow);
+      } else {
+        const det = document.getElementById('ticketDetail');
+        if (det) det.style.display = 'none';
+      }
+    });
+    els.tabProjects?.addEventListener('click', ()=> {
+      const first = DB.state.projects?.[0];
+      if (first){
+        UI.openProjectDetailInline(first);
+        document.querySelectorAll('#projectsCarousel .project.selected').forEach(el=>el.classList.remove('selected'));
+        const firstCard = document.querySelector('#projectsCarousel .project');
+        firstCard?.classList.add('selected');
+      } else {
+        UI.setActiveTab('projects');
+      }
+    });
+    els.tabAdmin?.addEventListener('click', (e)=> {
+      e.stopPropagation();
       setPageState('default');
-      els.adminMenu?.classList.toggle('open');
+      adminMenuOpen = !adminMenuOpen;
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
-    els.btnAdminCreateTicket?.addEventListener('click', ()=>{
+    els.btnAdminCreateTicket?.addEventListener('click', (e)=>{
+      e.stopPropagation();
       UI.showCreateTicket();
-      els.adminMenu?.classList.remove('open');
-      els.sidebar?.classList.remove('open');
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
-    els.btnAdminCreateProject?.addEventListener('click', ()=>{
+    els.btnAdminCreateProject?.addEventListener('click', (e)=>{
+      e.stopPropagation();
       UI.showCreateProject();
-      els.adminMenu?.classList.remove('open');
-      els.sidebar?.classList.remove('open');
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
-    els.btnAdminArchivedTickets?.addEventListener('click', ()=>{
+    els.btnAdminArchivedTickets?.addEventListener('click', (e)=>{
+      e.stopPropagation();
       UI.showArchivedTickets();
-      els.adminMenu?.classList.remove('open');
-      els.sidebar?.classList.remove('open');
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
-    els.btnAdminFinishedTickets?.addEventListener('click', ()=>{
+    els.btnAdminFinishedTickets?.addEventListener('click', (e)=>{
+      e.stopPropagation();
       UI.showFinishedTickets();
-      els.adminMenu?.classList.remove('open');
-      els.sidebar?.classList.remove('open');
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
-    els.btnAdminArchivedProjects?.addEventListener('click', ()=>{
+    els.btnAdminArchivedProjects?.addEventListener('click', (e)=>{
+      e.stopPropagation();
       UI.showArchivedProjects();
-      els.adminMenu?.classList.remove('open');
-      els.sidebar?.classList.remove('open');
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
-    els.btnAdminFinishedProjects?.addEventListener('click', ()=>{
+    els.btnAdminFinishedProjects?.addEventListener('click', (e)=>{
+      e.stopPropagation();
       hideAllSections();
       if (els.sectionFinishedProjects) els.sectionFinishedProjects.style.display = 'block';
       setPageState('default');
@@ -1370,8 +1512,7 @@
       document.body.classList.add('finished-projects-page');
       if (els.sectionPill) els.sectionPill.textContent = 'Projetos finalizados';
       UI.renderFinishedProjects();
-      els.adminMenu?.classList.remove('open');
-      els.sidebar?.classList.remove('open');
+      adminMenu?.classList.toggle('open', adminMenuOpen);
     });
 
     // Boot inicial

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -143,6 +143,10 @@
     return Math.max(0, pct);
   }
 
+  function cssVar(name){
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
   // ===== Observações: utils =====
   function isAdminUser(){
     return CURRENT_ROLE === 'admin';
@@ -211,6 +215,8 @@
     const panel = document.getElementById(panelId);
     if (!panel) return;
 
+    const wasActive = panel.classList.contains('active');
+
     const items = owner.observacoes;
     const listHtml = items.length ? `
       <ul id="${panelId}List" style="display:grid; gap:8px; margin-left:18px">
@@ -243,10 +249,12 @@
     ` : ``;
 
     panel.innerHTML = listHtml + formHtml;
+    if (wasActive) { panel.classList.add('active'); panel.style.display = ''; }
 
     if (admin){
       const addBtn = document.getElementById(`${panelId}Add`);
-      addBtn?.addEventListener('click', () => {
+      addBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
         const ta = document.getElementById(`${panelId}Input`);
         const txt = (ta?.value || '').trim();
         if (!txt) return;
@@ -261,6 +269,7 @@
       });
 
       panel.addEventListener('click', (e) => {
+        e.stopPropagation();
         const btn = e.target.closest('button[data-act]');
         if (!btn) return;
         const li = btn.closest('li[data-id]');
@@ -285,8 +294,9 @@
               <button class="btn btn-primary btn-sm" data-act="save">Salvar</button>
             </div>
           `;
-          li.querySelector('[data-act="cancel"]').addEventListener('click', () => renderObsList(owner, panelId, saveFn));
-          li.querySelector('[data-act="save"]').addEventListener('click', () => {
+          li.querySelector('[data-act="cancel"]').addEventListener('click', (ev) => { ev.stopPropagation(); renderObsList(owner, panelId, saveFn); });
+          li.querySelector('[data-act="save"]').addEventListener('click', (ev) => {
+            ev.stopPropagation();
             const nv = li.querySelector('.obs-edit').value.trim();
             owner.observacoes[idx].texto = nv;
             saveFn(owner);
@@ -303,6 +313,61 @@
 
   function renderProjectObservacoes(proj){
     renderObsList(proj, 'pdObs', p => DB.updateProject(p.id, {observacoes: p.observacoes, obs: null}));
+  }
+
+  function renderNotesList(owner, panelId, addFn, delFn){
+    const panel = document.getElementById(panelId);
+    if (!panel) return;
+    const notes = owner.notes || (owner.notes = []);
+    const admin = isAdminUser();
+    const wasActive = panel.classList.contains('active');
+
+    panel.innerHTML = `
+      <ul id="${panelId}List" style="display:grid; gap:6px; margin-left:18px">
+        ${notes.map((n,i)=>`
+          <li data-idx="${i}" style="display:flex; gap:8px; align-items:flex-start">
+            <div style="flex:1"><b>${esc(n.user)}:</b> ${esc(n.text)}</div>
+            ${(admin || n.user === CURRENT_USER) ? `<button class="btn btn-danger btn-sm" data-act="del">Excluir</button>` : ''}
+          </li>
+        `).join('') || '<li>Nenhuma anotação.</li>'}
+      </ul>
+      <div id="${panelId}Form" style="margin-top:8px">
+        <textarea id="${panelId}Input" style="width:100%; min-height:120px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Anotações..."></textarea>
+        <div class="actions" style="margin-top:6px">
+          <button type="button" class="btn btn-primary btn-sm" id="${panelId}Add">Adicionar</button>
+        </div>
+      </div>`;
+
+    if (wasActive) { panel.classList.add('active'); panel.style.display=''; }
+
+    panel.querySelector(`#${panelId}Add`)?.addEventListener('click', e=>{
+      e.stopPropagation();
+      const ta = panel.querySelector(`#${panelId}Input`);
+      const text = ta.value.trim();
+      if (!text) return;
+      addFn(owner, text);
+      ta.value='';
+      renderNotesList(owner, panelId, addFn, delFn);
+    });
+
+    panel.addEventListener('click', e=>{
+      e.stopPropagation();
+      const btn = e.target.closest('button[data-act="del"]');
+      if (!btn) return;
+      const li = btn.closest('li[data-idx]');
+      if (!li) return;
+      const idx = Number(li.dataset.idx);
+      delFn(owner, idx);
+      renderNotesList(owner, panelId, addFn, delFn);
+    }, { once: true });
+  }
+
+  function renderTicketNotes(t){
+    renderNotesList(t, 'tdNotes', (owner, text) => UI.addTicketNote(owner, text), (owner, idx) => UI.deleteTicketNote(owner, idx));
+  }
+
+  function renderProjectNotes(p){
+    renderNotesList(p, 'pdNotes', (owner, text) => UI.addProjectNote(owner, text), (owner, idx) => UI.deleteProjectNote(owner, idx));
   }
 
   // ========== DASHBOARD ==========
@@ -972,23 +1037,7 @@
 
         renderObservacoes(t);
 
-        if (els.tdNotes) {
-          const listEl = qs('#tdNotesList', els.tdNotes);
-          const notes = t.notes || [];
-          if (listEl) listEl.innerHTML = notes.map(n=>`<li><b>${n.user}:</b> ${n.text}</li>`).join('') || '<li>Nenhuma anotação.</li>';
-          const form = qs('#tdNoteForm', els.tdNotes);
-          const btn = qs('#tdAddNoteBtn', form);
-          if (btn && !btn._bound) {
-            btn.addEventListener('click', ()=>{
-              const ta = qs('textarea', form);
-              const text = ta.value.trim();
-              if (!text) return;
-              UI.addTicketNote(t, text);
-              ta.value = '';
-            });
-            btn._bound = true;
-          }
-        }
+        renderTicketNotes(t);
 
 
         const list = DB.state.rdosByTicket[t.id] || [];
@@ -1125,7 +1174,9 @@
 
       async addTicketNote(t, text){
         await DB.addTicketNote(t.id, text, CURRENT_USER);
-        UI.openTicketDetail(t);
+      },
+      async deleteTicketNote(t, idx){
+        await DB.deleteTicketNote(t.id, idx);
       },
 
       async editTicket(t, updated){
@@ -1187,7 +1238,9 @@
 
       async addProjectNote(p, text){
         await DB.addProjectNote(p.id, text, CURRENT_USER);
-        UI.openProjectDetailInline(p);
+      },
+      async deleteProjectNote(p, idx){
+        await DB.deleteProjectNote(p.id, idx);
       },
 
       async deleteProject(p){
@@ -1292,22 +1345,7 @@
           <div class="subtab-panel" id="pdEditForm" style="display:none;padding-top:10px"></div>
         </div>`;
 
-        const notesPanel = qs('#pdNotes', els.projDetailsInline);
-        const nList = qs('#pdNotesList', notesPanel);
-        const notes = p.notes || [];
-        if (nList) nList.innerHTML = notes.map(n=>`<li><b>${n.user}:</b> ${n.text}</li>`).join('') || '<li>Nenhuma anotação.</li>';
-        const nForm = qs('#pdNoteForm', notesPanel);
-        const nBtn = qs('#pdAddNoteBtn', nForm);
-        if (nBtn && !nBtn._bound){
-          nBtn.addEventListener('click', ()=>{
-            const ta = qs('textarea', nForm);
-            const text = ta.value.trim();
-            if (!text) return;
-            UI.addProjectNote(p, text);
-            ta.value = '';
-          });
-          nBtn._bound = true;
-        }
+        renderProjectNotes(p);
 
         renderProjectObservacoes(p);
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -103,16 +103,44 @@
     return new Date(str);
   }
 
-  // Calcula % de prazo consumido com base em createdAt e dueDate
-  function computePrazoPct(createdAt, dueDate, now = new Date()){
-    const end = parseDateLocal(dueDate);
-    if (isNaN(end)) return 0;
-    let start = parseDateLocal(createdAt);
-    if (isNaN(start)) start = now;
-    const total = end - start;
-    if (total <= 0) return 0;
-    const elapsed = now - start;
-    return Math.max(0, Math.round((elapsed / total) * 100));
+  // === Datas robustas ===
+  function parseDateSmart(v){
+    if (!v) return null;
+    if (v instanceof Date) return v;
+    if (typeof v === 'number') return new Date(v);
+
+    const s = String(v).trim();
+
+    const iso = s.match(/^(\d{4})[-\/](\d{1,2})[-\/](\d{1,2})(?:[ T].*)?$/);
+    if (iso){
+      const y = +iso[1], m = +iso[2]-1, d = +iso[3];
+      return new Date(y, m, d);
+    }
+
+    const br = s.match(/^(\d{1,2})[-\/](\d{1,2})[-\/](\d{4})$/);
+    if (br){
+      const d = +br[1], m = +br[2]-1, y = +br[3];
+      return new Date(y, m, d);
+    }
+
+    const dt = new Date(s);
+    return isNaN(dt.getTime()) ? null : dt;
+  }
+
+  // progresso de prazo (0..∞)
+  function computeDeadlinePct(startDate, endDate, now = new Date()){
+    const a = parseDateSmart(startDate);
+    const b = parseDateSmart(endDate);
+    if (!a || !b) return 0;
+
+    const total = b.getTime() - a.getTime();
+    if (total <= 0){
+      return now > b ? 200 : 0;
+    }
+
+    const elapsed = now.getTime() - a.getTime();
+    const pct = (elapsed / total) * 100;
+    return Math.max(0, pct);
   }
 
   // Controla classes do <body> conforme a página
@@ -259,7 +287,7 @@
       _renderOverview(){
         const t = this._selected || DB.state.tickets[0];
         if (!t) return;
-        const p = computePrazoPct(t.createdAt, t.dueDate);
+        const p = computeDeadlinePct(t.createdAt, t.dueDate);
         this.renderSLAChart(t.concl, Math.min(p,100), 'chartSLA');
       },
 
@@ -303,9 +331,9 @@
           })
           .forEach(t => {
           const tr = document.createElement('tr');
-          const prazoPct = computePrazoPct(t.createdAt, t.dueDate);
-          const overdue = parseDateLocal(t.dueDate) < new Date();
-          const prazoClass = overdue ? 'overdue' : '';
+          const pctPrazo = computeDeadlinePct(t.createdAt, t.dueDate);
+          const pctPrazoCapped = Math.min(100, Math.round(pctPrazo));
+          const overdue = pctPrazo > 100 ? 'overdue' : '';
           tr.innerHTML = `
             <td data-label="ID do chamado"><button class="linklike" data-id="${t.id}">${t.id}</button></td>
             <td data-label="Data de criação">${fmtDate(t.createdAt)}</td>
@@ -319,9 +347,9 @@
               </div>
             </td>
             <td data-label="% de prazo">
-              <div class="prog ${prazoClass}">
-                <div class="nums"><span>Prazo: <b>${prazoPct}%</b></span></div>
-                <div class="progress"><i style="width:${Math.min(prazoPct,100)}%"></i></div>
+              <div class="prog ${overdue}">
+                <div class="nums"><span>Prazo: <b>${Math.round(pctPrazo)}%</b></span></div>
+                <div class="progress ${overdue}"><i style="width:${pctPrazoCapped}%"></i></div>
               </div>
             </td>
           `;
@@ -383,9 +411,9 @@
         els.archivedTicketsBody.innerHTML='';
         DB.state.archivedTickets.forEach(t=>{
           const tr=document.createElement('tr');
-          const prazoPct=computePrazoPct(t.createdAt,t.dueDate);
-          const overdue=parseDateLocal(t.dueDate)<new Date();
-          const prazoClass=overdue?'overdue':'';
+          const pctPrazo=computeDeadlinePct(t.createdAt,t.dueDate);
+          const pctPrazoCapped=Math.min(100,Math.round(pctPrazo));
+          const overdue=pctPrazo>100?'overdue':'';
           tr.innerHTML=`
             <td data-label="ID do chamado">${t.id}</td>
             <td data-label="Data de criação">${fmtDate(t.createdAt)}</td>
@@ -395,7 +423,7 @@
               <div class="prog"><div class="nums"><span>Concl.: <b>${t.concl}%</b></span></div><div class="progress"><i style="width:${t.concl}%"></i></div></div>
             </td>
             <td data-label="% de prazo">
-              <div class="prog ${prazoClass}"><div class="nums"><span>Prazo: <b>${prazoPct}%</b></span></div><div class="progress"><i style="width:${Math.min(prazoPct,100)}%"></i></div></div>
+              <div class="prog ${overdue}"><div class="nums"><span>Prazo: <b>${Math.round(pctPrazo)}%</b></span></div><div class="progress ${overdue}"><i style="width:${pctPrazoCapped}%"></i></div></div>
             </td>
             <td class="actions-cell"><button class="restore btn btn-outline btn-sm" data-id="${t.id}">Restaurar</button> <button class="delete btn btn-danger btn-sm" data-id="${t.id}">Excluir</button></td>
           `;
@@ -416,9 +444,9 @@
         els.finishedTicketsBody.innerHTML='';
         DB.state.finishedTickets.forEach(t=>{
           const tr=document.createElement('tr');
-          const prazoPct=computePrazoPct(t.createdAt,t.dueDate);
-          const overdue=parseDateLocal(t.dueDate)<new Date();
-          const prazoClass=overdue?'overdue':'';
+          const pctPrazo=computeDeadlinePct(t.createdAt,t.dueDate);
+          const pctPrazoCapped=Math.min(100,Math.round(pctPrazo));
+          const overdue=pctPrazo>100?'overdue':'';
           tr.innerHTML=`
             <td data-label="ID do chamado">${t.id}</td>
             <td data-label="Data de criação">${fmtDate(t.createdAt)}</td>
@@ -428,7 +456,7 @@
               <div class="prog"><div class="nums"><span>Concl.: <b>${t.concl}%</b></span></div><div class="progress"><i style="width:${t.concl}%"></i></div></div>
             </td>
             <td data-label="% de prazo">
-              <div class="prog ${prazoClass}"><div class="nums"><span>Prazo: <b>${prazoPct}%</b></span></div><div class="progress"><i style="width:${Math.min(prazoPct,100)}%"></i></div></div>
+              <div class="prog ${overdue}"><div class="nums"><span>Prazo: <b>${Math.round(pctPrazo)}%</b></span></div><div class="progress ${overdue}"><i style="width:${pctPrazoCapped}%"></i></div></div>
             </td>
             <td class="actions-cell"><button class="restore btn btn-outline btn-sm" data-id="${t.id}">Restaurar</button> <button class="delete btn btn-danger btn-sm" data-id="${t.id}">Excluir</button></td>
           `;
@@ -746,7 +774,7 @@
         this._selected = t;
         if(this._selectedRow){ this._selectedRow.classList.remove('selected'); }
         if(rowEl){ rowEl.classList.add('selected'); this._selectedRow = rowEl; }
-        const p = computePrazoPct(t.createdAt, t.dueDate);
+        const p = computeDeadlinePct(t.createdAt, t.dueDate);
         this.renderSLAChart(t.concl, Math.min(p,100));
       },
 
@@ -754,12 +782,17 @@
         this.selectTicket(t, rowEl);
         this.setActiveTab('tickets');
 
+        const pctPrazo = computeDeadlinePct(t.createdAt, t.dueDate);
+        const overdue = pctPrazo > 100;
+        const dueObj = parseDateSmart(t.dueDate);
+
         if (els.tdTitle) els.tdTitle.textContent = t.id;
-        if (els.tdPct) els.tdPct.textContent = `${t.concl}%`;
+        if (els.tdPct) {
+          els.tdPct.textContent = `${Math.round(pctPrazo)}%`;
+          els.tdPct.classList.toggle('overdue', overdue);
+        }
         if (els.tdMeta) {
-          const prazoPct = computePrazoPct(t.createdAt, t.dueDate);
-          const overdue = parseDateLocal(t.dueDate) < new Date();
-          const maybeDue = t.dueDate ? `<span><b>Prazo final:</b> ${parseDateLocal(t.dueDate).toLocaleDateString('pt-BR')}</span>` : '';
+          const maybeDue = dueObj ? `<span><b>Prazo final:</b> ${dueObj.toLocaleDateString('pt-BR')}</span>` : '';
           els.tdMeta.innerHTML = `
             <span><b>Data:</b> ${fmtDate(t.createdAt)}</span>
             <span><b>Aberto por:</b> ${t.solicitante}</span>
@@ -767,14 +800,25 @@
             <span><b>Ponto de encontro:</b> ${t.meetPoint}</span>
             <span><b>Dupla:</b> ${t.dupla}</span>
             ${maybeDue}
-            <span class="${overdue ? 'overdue' : ''}"><b>Prazo consumido:</b> ${prazoPct}%</span>`;
+            <span class="${overdue ? 'overdue' : ''}"><b>Prazo consumido:</b> ${Math.round(pctPrazo)}%</span>`;
         }
 
         if (els.tdDesc) {
-          els.tdDesc.innerHTML = `
-            <p><b>Resumo:</b> ${t.resumo}</p>
-            <p>${t.descricao}</p>
+          const resumo = `
+            <h4>Resumo</h4>
+            <p>${(t.resumo || '').trim() || '—'}</p>
           `;
+          const descricao = t.descricao ? `
+            <div class="divider"></div>
+            <h4>Descrição</h4>
+            <p>${t.descricao}</p>
+          ` : '';
+          const observ = t.obs ? `
+            <div class="divider"></div>
+            <h4>Observações</h4>
+            <p>${t.obs}</p>
+          ` : '';
+          els.tdDesc.innerHTML = `<div class="td-desc">${resumo}${descricao}${observ}</div>`;
         }
 
         if (els.tdNotes) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -154,18 +154,18 @@
       .replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
   }
 
-  function ensureObsArray(ticket){
-    if (!ticket.observacoes) {
-      ticket.observacoes = ticket.obs || [];
-      delete ticket.obs;
+  function ensureObsArray(item){
+    if (!item.observacoes || item.observacoes.length === 0) {
+      if (item.obs) item.observacoes = item.obs;
     }
-    if (typeof ticket.observacoes === 'string'){
-      ticket.observacoes = [{ id: Date.now(), texto: ticket.observacoes, autor: 'sistema', criadoEm: new Date() }];
+    delete item.obs;
+    if (typeof item.observacoes === 'string'){
+      item.observacoes = [{ id: Date.now(), texto: item.observacoes, autor: 'sistema', criadoEm: new Date() }];
     }
-    if (!Array.isArray(ticket.observacoes)){
-      ticket.observacoes = [ticket.observacoes];
+    if (!Array.isArray(item.observacoes)){
+      item.observacoes = [item.observacoes];
     }
-    ticket.observacoes = ticket.observacoes.map((o,i) => ({
+    item.observacoes = item.observacoes.map((o,i) => ({
       id: o?.id ?? (Date.now()+i),
       texto: String(o?.texto ?? o?.text ?? o ?? ''),
       autor: o?.autor ?? o?.author ?? '—',
@@ -205,15 +205,15 @@
     });
   }
 
-  function renderObservacoes(ticket){
-    ensureObsArray(ticket);
+  function renderObsList(owner, panelId, saveFn){
+    ensureObsArray(owner);
     const admin = isAdminUser();
-    const panel = document.getElementById('tdObs');
+    const panel = document.getElementById(panelId);
     if (!panel) return;
 
-    const items = ticket.observacoes;
+    const items = owner.observacoes;
     const listHtml = items.length ? `
-      <ul id="tdObsList" style="display:grid; gap:8px; margin-left:18px">
+      <ul id="${panelId}List" style="display:grid; gap:8px; margin-left:18px">
         ${items.map(o => `
           <li data-id="${o.id}" style="display:flex; gap:8px; align-items:flex-start">
             <div style="flex:1">
@@ -223,21 +223,21 @@
             ${admin ? `
               <div class="actions-cell">
                 <button class="btn btn-outline btn-sm" data-act="edit">Editar</button>
-                <button class="btn btn-danger  btn-sm" data-act="del">Excluir</button>
+                <button class="btn btn-danger btn-sm" data-act="del">Excluir</button>
               </div>
             ` : ``}
           </li>
         `).join('')}
       </ul>
     ` : `
-      <div id="tdObsList"></div>
+      <div id="${panelId}List"></div>
     `;
 
     const formHtml = admin ? `
-      <div id="tdObsForm" style="margin-top:10px">
-        <textarea id="tdObsInput" style="width:100%; min-height:100px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Adicionar observação..."></textarea>
+      <div id="${panelId}Form" style="margin-top:10px">
+        <textarea id="${panelId}Input" style="width:100%; min-height:100px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Adicionar observação..."></textarea>
         <div class="actions" style="margin-top:6px">
-          <button type="button" class="btn btn-primary btn-sm" id="tdObsAdd">Adicionar</button>
+          <button type="button" class="btn btn-primary btn-sm" id="${panelId}Add">Adicionar</button>
         </div>
       </div>
     ` : ``;
@@ -245,34 +245,36 @@
     panel.innerHTML = listHtml + formHtml;
 
     if (admin){
-      const addBtn = document.getElementById('tdObsAdd');
+      const addBtn = document.getElementById(`${panelId}Add`);
       addBtn?.addEventListener('click', () => {
-        const ta = document.getElementById('tdObsInput');
+        const ta = document.getElementById(`${panelId}Input`);
         const txt = (ta?.value || '').trim();
         if (!txt) return;
-        ticket.observacoes.push({
+        owner.observacoes.push({
           id: Date.now(),
           texto: txt,
           autor: CURRENT_USER || 'admin',
           criadoEm: new Date()
         });
-        renderObservacoes(ticket);
+        saveFn(owner);
+        renderObsList(owner, panelId, saveFn);
       });
 
-      document.getElementById('tdObs')?.addEventListener('click', (e) => {
+      panel.addEventListener('click', (e) => {
         const btn = e.target.closest('button[data-act]');
         if (!btn) return;
         const li = btn.closest('li[data-id]');
         if (!li) return;
         const id = li.getAttribute('data-id');
-        const idx = ticket.observacoes.findIndex(o => String(o.id) === String(id));
+        const idx = owner.observacoes.findIndex(o => String(o.id) === String(id));
         if (idx < 0) return;
 
         if (btn.dataset.act === 'del'){
-          ticket.observacoes.splice(idx, 1);
-          renderObservacoes(ticket);
+          owner.observacoes.splice(idx, 1);
+          saveFn(owner);
+          renderObsList(owner, panelId, saveFn);
         } else if (btn.dataset.act === 'edit'){
-          const o = ticket.observacoes[idx];
+          const o = owner.observacoes[idx];
           li.innerHTML = `
             <div style="flex:1; display:grid; gap:6px">
               <textarea class="obs-edit" style="width:100%; min-height:100px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px">${esc(o.texto)}</textarea>
@@ -283,15 +285,24 @@
               <button class="btn btn-primary btn-sm" data-act="save">Salvar</button>
             </div>
           `;
-          li.querySelector('[data-act="cancel"]').addEventListener('click', () => renderObservacoes(ticket));
+          li.querySelector('[data-act="cancel"]').addEventListener('click', () => renderObsList(owner, panelId, saveFn));
           li.querySelector('[data-act="save"]').addEventListener('click', () => {
             const nv = li.querySelector('.obs-edit').value.trim();
-            ticket.observacoes[idx].texto = nv;
-            renderObservacoes(ticket);
+            owner.observacoes[idx].texto = nv;
+            saveFn(owner);
+            renderObsList(owner, panelId, saveFn);
           });
         }
       }, { once: true });
     }
+  }
+
+  function renderObservacoes(ticket){
+    renderObsList(ticket, 'tdObs', t => DB.updateTicket(t.id, {observacoes: t.observacoes, obs: null}));
+  }
+
+  function renderProjectObservacoes(proj){
+    renderObsList(proj, 'pdObs', p => DB.updateProject(p.id, {observacoes: p.observacoes, obs: null}));
   }
 
   // ========== DASHBOARD ==========
@@ -1179,12 +1190,6 @@
         UI.openProjectDetailInline(p);
       },
 
-      async saveProjectObs(p, text){
-        if (CURRENT_ROLE !== 'admin') return;
-        await DB.setProjectObs(p.id, text, CURRENT_USER);
-        UI.openProjectDetailInline(p);
-      },
-
       async deleteProject(p){
         if(!confirm('Excluir projeto?')) return;
         await DB.finishProject(p);
@@ -1218,8 +1223,12 @@
       renderSLAChart(concl, prazo, targetId='chartSLA'){
         const svg = targetId ? qs('#'+targetId) : els.chartSLA;
         if (!svg) return;
-        const c = Math.max(0, Math.min(100, concl||0));
-        const p = Math.max(0, Math.min(100, prazo||0));
+        const cRaw = Math.max(0, concl || 0);
+        const pRaw = Math.max(0, prazo || 0);
+        const c = Math.min(100, cRaw);
+        const p = Math.min(100, pRaw);
+        const cText = Math.round(cRaw);
+        const pText = Math.round(pRaw);
         svg.innerHTML = `
           <defs>
             <linearGradient id="gradC" x1="0" x2="0" y1="0" y2="1">
@@ -1232,8 +1241,8 @@
           <rect x="2" y="24" width="96" height="8" rx="2" fill="#0f131a" stroke="${cssVar('--card-border')}"/>
           <rect x="2" y="24" width="${c*0.96}" height="8" rx="2" fill="url(#gradC)" />
           <g fill="#9aa0a6" font-size="3.2">
-            <text x="2" y="8">Prazo consumido: ${p}%</text>
-            <text x="2" y="36">Conclusão: ${c}%</text>
+            <text x="2" y="8">Prazo consumido: ${pText}%</text>
+            <text x="2" y="36">Conclusão: ${cText}%</text>
           </g>`;
       },
 
@@ -1300,20 +1309,7 @@
           nBtn._bound = true;
         }
 
-        const obsPanel = qs('#pdObs', els.projDetailsInline);
-        const obs = p.obs || {};
-        if (CURRENT_ROLE === 'admin') {
-          obsPanel.innerHTML = `<form id="pdObsForm"><textarea style="width:100%; min-height:120px; background:#0f131a; border:1px solid var(--card-border); border-radius:10px; color:var(--text); padding:10px" placeholder="Observações gerais..." autocomplete="off">${obs.text||''}</textarea><div class="actions" style="margin-top:6px"><button type="submit" class="btn btn-primary">Salvar</button></div></form>`;
-          const oform = qs('#pdObsForm', obsPanel);
-          oform.addEventListener('submit', ev=>{
-            ev.preventDefault();
-            const text = qs('textarea', oform).value.trim();
-            UI.saveProjectObs(p, text);
-          });
-        } else {
-          const content = obs.text ? `<p>${obs.text}${obs.user ? `<br><small>por ${obs.user}</small>` : ''}</p>` : '<p>Nenhuma observação.</p>';
-          obsPanel.innerHTML = content;
-        }
+        renderProjectObservacoes(p);
 
         // Construção do form de edição
         const form = document.createElement('form');

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -363,11 +363,21 @@
   }
 
   function renderTicketNotes(t){
-    renderNotesList(t, 'tdNotes', (owner, text) => UI.addTicketNote(owner, text), (owner, idx) => UI.deleteTicketNote(owner, idx));
+    renderNotesList(
+      t,
+      'tdNotes',
+      (owner, text) => DB.addTicketNote(owner.id, text, CURRENT_USER),
+      (owner, idx) => DB.deleteTicketNote(owner.id, idx)
+    );
   }
 
   function renderProjectNotes(p){
-    renderNotesList(p, 'pdNotes', (owner, text) => UI.addProjectNote(owner, text), (owner, idx) => UI.deleteProjectNote(owner, idx));
+    renderNotesList(
+      p,
+      'pdNotes',
+      (owner, text) => DB.addProjectNote(owner.id, text, CURRENT_USER),
+      (owner, idx) => DB.deleteProjectNote(owner.id, idx)
+    );
   }
 
   // ========== DASHBOARD ==========

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -115,6 +115,34 @@
     return Math.max(0, Math.round((elapsed / total) * 100));
   }
 
+  // Controla classes do <body> conforme a página
+  function setPageState(state){
+    document.body.classList.remove('create-page','create-ticket-page','create-project-page');
+    switch(state){
+      case 'create-ticket':
+        document.body.classList.add('create-page','create-ticket-page');
+        break;
+      case 'create-project':
+        document.body.classList.add('create-page','create-project-page');
+        break;
+      default:
+        // estado normal
+        break;
+    }
+  }
+
+  function hideAllSections(){
+    [
+      'sectionTickets','sectionCharts','sectionProjects',
+      'sectionCreateTicket','sectionCreateProject',
+      'sectionArchivedTickets','sectionFinishedTickets',
+      'sectionArchivedProjects','sectionFinishedProjects'
+    ].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.style.display = 'none';
+    });
+  }
+
   // ========== DASHBOARD ==========
   function initDashboard(){
     const els = {
@@ -190,12 +218,8 @@
     const UI = {
       setActiveTab(which){
         [els.tabOverview, els.tabTickets, els.tabProjects].forEach(b=> b?.classList.remove('active'));
-        hide('#sectionCreateTicket');
-        hide('#sectionCreateProject');
-        hide('#sectionArchivedTickets');
-        hide('#sectionFinishedTickets');
-        hide('#sectionArchivedProjects');
-        hide('#sectionFinishedProjects');
+        hideAllSections();
+        setPageState('default');
 
         document.body.classList.remove('projects-page','tickets-page');
         if (which === 'projects') document.body.classList.add('projects-page');
@@ -208,8 +232,8 @@
         if (which === 'overview') {
           els.tabOverview?.classList.add('active');
           if (els.sectionPill) els.sectionPill.textContent = 'Dashboard';
-          show('#sectionTickets'); 
-          show('#sectionCharts'); 
+          show('#sectionTickets');
+          show('#sectionCharts');
           show('#sectionProjects');
 
           clearTicketDetail(els);
@@ -219,17 +243,13 @@
         if (which === 'tickets') {
           els.tabTickets?.classList.add('active');
           if (els.sectionPill) els.sectionPill.textContent = 'Chamados';
-          show('#sectionTickets'); 
-          hide('#sectionCharts'); 
-          hide('#sectionProjects');
+          show('#sectionTickets');
           return;
         }
 
         if (which === 'projects') {
           els.tabProjects?.classList.add('active');
           if (els.sectionPill) els.sectionPill.textContent = 'Projetos';
-          hide('#sectionTickets'); 
-          hide('#sectionCharts'); 
           show('#sectionProjects');
           clearTicketDetail(els);
           return;
@@ -471,11 +491,9 @@
       },
 
       showCreateTicket(){
-        hide('#sectionTickets');
-        hide('#sectionCharts');
-        hide('#sectionProjects');
-        hide('#sectionCreateProject');
+        hideAllSections();
         show('#sectionCreateTicket');
+        setPageState('create-ticket');
         document.body.classList.remove('tickets-page','projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Criar chamado';
 
@@ -596,11 +614,9 @@
       },
 
       showCreateProject(){
-        hide('#sectionTickets');
-        hide('#sectionCharts');
-        hide('#sectionProjects');
-        hide('#sectionCreateTicket');
+        hideAllSections();
         show('#sectionCreateProject');
+        setPageState('create-project');
         document.body.classList.remove('tickets-page','projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Criar projeto';
 
@@ -696,32 +712,36 @@
 
 
       showArchivedTickets(){
-        hide('#sectionTickets'); hide('#sectionCharts'); hide('#sectionProjects'); hide('#sectionCreateTicket'); hide('#sectionCreateProject'); hide('#sectionFinishedTickets'); hide('#sectionArchivedProjects'); hide('#sectionFinishedProjects');
+        hideAllSections();
         show('#sectionArchivedTickets');
+        setPageState('default');
         document.body.classList.add('tickets-page');
         document.body.classList.remove('projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Chamados arquivados';
         this.renderArchivedTickets();
       },
       showFinishedTickets(){
-        hide('#sectionTickets'); hide('#sectionCharts'); hide('#sectionProjects'); hide('#sectionCreateTicket'); hide('#sectionCreateProject'); hide('#sectionArchivedTickets'); hide('#sectionArchivedProjects'); hide('#sectionFinishedProjects');
+        hideAllSections();
         show('#sectionFinishedTickets');
+        setPageState('default');
         document.body.classList.add('tickets-page');
         document.body.classList.remove('projects-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Chamados finalizados';
         this.renderFinishedTickets();
       },
       showArchivedProjects(){
-        hide('#sectionTickets'); hide('#sectionCharts'); hide('#sectionProjects'); hide('#sectionCreateTicket'); hide('#sectionCreateProject'); hide('#sectionArchivedTickets'); hide('#sectionFinishedTickets'); hide('#sectionFinishedProjects');
+        hideAllSections();
         show('#sectionArchivedProjects');
+        setPageState('default');
         document.body.classList.add('projects-page');
         document.body.classList.remove('tickets-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Projetos arquivados';
         this.renderArchivedProjects();
       },
       showFinishedProjects(){
-        hide('#sectionTickets'); hide('#sectionCharts'); hide('#sectionProjects'); hide('#sectionCreateTicket'); hide('#sectionCreateProject'); hide('#sectionArchivedTickets'); hide('#sectionFinishedTickets'); hide('#sectionArchivedProjects');
+        hideAllSections();
         show('#sectionFinishedProjects');
+        setPageState('default');
         document.body.classList.add('projects-page');
         document.body.classList.remove('tickets-page');
         if (els.sectionPill) els.sectionPill.textContent = 'Projetos finalizados';
@@ -1273,7 +1293,10 @@
     els.tabOverview?.addEventListener('click', ()=> UI.setActiveTab('overview'));
     els.tabTickets?.addEventListener('click', ()=> UI.setActiveTab('tickets'));
     els.tabProjects?.addEventListener('click', ()=> UI.setActiveTab('projects'));
-    els.tabAdmin?.addEventListener('click', ()=> els.adminMenu?.classList.toggle('open'));
+    els.tabAdmin?.addEventListener('click', ()=> {
+      setPageState('default');
+      els.adminMenu?.classList.toggle('open');
+    });
     els.btnAdminCreateTicket?.addEventListener('click', ()=>{
       UI.showCreateTicket();
       els.adminMenu?.classList.remove('open');

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -208,6 +208,20 @@ const DB = {
       console.warn('Não foi possível salvar anotação', e);
     }
   },
+  async deleteTicketNote(id, idx){
+    const t = this.state.tickets.find(x=>x.id===id);
+    if(!t || !t.notes) return;
+    t.notes.splice(idx,1);
+    try{
+      await fetch('/api/db', {
+        method:'PATCH',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({tickets:{[id]: {notes: t.notes}}})
+      });
+    }catch(e){
+      console.warn('Não foi possível excluir anotação', e);
+    }
+  },
   async addProjectNote(id, text, user){
     const p = this.state.projects.find(x=>x.id===id);
     if(!p) return;
@@ -221,6 +235,20 @@ const DB = {
       });
     }catch(e){
       console.warn('Não foi possível salvar anotação', e);
+    }
+  },
+  async deleteProjectNote(id, idx){
+    const p = this.state.projects.find(x=>x.id===id);
+    if(!p || !p.notes) return;
+    p.notes.splice(idx,1);
+    try{
+      await fetch('/api/db', {
+        method:'PATCH',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({projects:{[id]: {notes: p.notes}}})
+      });
+    }catch(e){
+      console.warn('Não foi possível excluir anotação', e);
     }
   },
   async archiveTicket(t){

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -43,7 +43,7 @@ const DB = {
     this.state.tickets = Object
       .entries(data.tickets || {})
       .filter(([,t]) => t && typeof t === 'object')
-      .map(([id, t]) => ({ id, ...t, notes: t.notes || [], obs: t.obs || {} }))
+      .map(([id, t]) => ({ id, ...t, notes: t.notes || [], obs: t.obs || {}, observacoes: t.observacoes || [] }))
       .sort((a, b) => {
         const da = parseDateLocal(a.dueDate);
         const db = parseDateLocal(b.dueDate);
@@ -54,7 +54,7 @@ const DB = {
     this.state.archivedTickets = Object
       .entries(data.archivedTickets || {})
       .filter(([,t]) => t && typeof t === 'object')
-      .map(([id, t]) => ({ id, ...t, notes: t.notes || [], obs: t.obs || {} }))
+      .map(([id, t]) => ({ id, ...t, notes: t.notes || [], obs: t.obs || {}, observacoes: t.observacoes || [] }))
       .sort((a, b) => {
         const da = parseDateLocal(a.dueDate);
         const db = parseDateLocal(b.dueDate);
@@ -65,7 +65,7 @@ const DB = {
     this.state.finishedTickets = Object
       .entries(data.finishedTickets || {})
       .filter(([,t]) => t && typeof t === 'object')
-      .map(([id, t]) => ({ id, ...t, notes: t.notes || [], obs: t.obs || {} }))
+      .map(([id, t]) => ({ id, ...t, notes: t.notes || [], obs: t.obs || {}, observacoes: t.observacoes || [] }))
       .sort((a, b) => {
         const da = parseDateLocal(a.dueDate);
         const db = parseDateLocal(b.dueDate);
@@ -76,17 +76,17 @@ const DB = {
     this.state.projects = Object
       .entries(data.projects || {})
       .filter(([,p]) => p && typeof p === 'object')
-      .map(([id, p]) => ({ id, ...p, notes: p.notes || [], obs: p.obs || {} }))
+      .map(([id, p]) => ({ id, ...p, notes: p.notes || [], obs: p.obs || {}, observacoes: p.observacoes || [] }))
       .sort((a, b) => parseDateLocal(a.prazo) - parseDateLocal(b.prazo));
     this.state.archivedProjects = Object
       .entries(data.archivedProjects || {})
       .filter(([,p]) => p && typeof p === 'object')
-      .map(([id, p]) => ({ id, ...p, notes: p.notes || [], obs: p.obs || {} }))
+      .map(([id, p]) => ({ id, ...p, notes: p.notes || [], obs: p.obs || {}, observacoes: p.observacoes || [] }))
       .sort((a, b) => parseDateLocal(a.prazo) - parseDateLocal(b.prazo));
     this.state.finishedProjects = Object
       .entries(data.finishedProjects || {})
       .filter(([,p]) => p && typeof p === 'object')
-      .map(([id, p]) => ({ id, ...p, notes: p.notes || [], obs: p.obs || {} }))
+      .map(([id, p]) => ({ id, ...p, notes: p.notes || [], obs: p.obs || {}, observacoes: p.observacoes || [] }))
       .sort((a, b) => parseDateLocal(a.prazo) - parseDateLocal(b.prazo));
     this.state.materialsByProject = data.materialsByProject || {};
     this.state.rdosByProject = data.rdosByProject || {};
@@ -118,6 +118,7 @@ const DB = {
     delete data.id;
     data.notes = data.notes || [];
     data.obs = data.obs || {};
+    data.observacoes = data.observacoes || [];
     this.state.tickets.push({ id, ...data });
     this.state.tickets.sort((a, b) => {
       const da = parseDateLocal(a.dueDate);
@@ -148,6 +149,7 @@ const DB = {
     delete data.id;
     data.notes = data.notes || [];
     data.obs = data.obs || {};
+    data.observacoes = data.observacoes || [];
     this.state.projects.push({ id, ...data });
     this.state.projects.sort((a, b) => parseDateLocal(a.prazo) - parseDateLocal(b.prazo));
     this.state.materialsByProject[id] = this.state.materialsByProject[id] || [];
@@ -206,20 +208,6 @@ const DB = {
       console.warn('Não foi possível salvar anotação', e);
     }
   },
-  async setTicketObs(id, text, user){
-    const t = this.state.tickets.find(x=>x.id===id);
-    if(!t) return;
-    t.obs = {text, user};
-    try{
-      await fetch('/api/db', {
-        method:'PATCH',
-        headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({tickets:{[id]: {obs: t.obs}}})
-      });
-    }catch(e){
-      console.warn('Não foi possível salvar observação', e);
-    }
-  },
   async addProjectNote(id, text, user){
     const p = this.state.projects.find(x=>x.id===id);
     if(!p) return;
@@ -233,20 +221,6 @@ const DB = {
       });
     }catch(e){
       console.warn('Não foi possível salvar anotação', e);
-    }
-  },
-  async setProjectObs(id, text, user){
-    const p = this.state.projects.find(x=>x.id===id);
-    if(!p) return;
-    p.obs = {text, user};
-    try{
-      await fetch('/api/db', {
-        method:'PATCH',
-        headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({projects:{[id]: {obs: p.obs}}})
-      });
-    }catch(e){
-      console.warn('Não foi possível salvar observação', e);
     }
   },
   async archiveTicket(t){

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -27,9 +27,32 @@ const tpl = {
             <input class="input" id="pass" name="pass" type="password" placeholder="••••" autocomplete="current-password" />
             <small class="label">Dica de teste: admin / 1234 ou filipe / 1234</small>
           </div>
-          <button id="btnContinue" class="continue" type="submit" disabled>Continuar</button>
-        </form>
+      <button id="btnContinue" class="continue" type="submit" disabled>Continuar</button>
+    </form>
       </main>` ,
+
+  loginMobile: () => `
+    <main class="card mobile">
+      <header class="brand">
+        <div class="logo"></div>
+        <div class="brand-text">
+          <div class="title">Telemix</div>
+          <p class="subtitle">Entrar</p>
+        </div>
+      </header>
+      <form id="loginForm" novalidate>
+        <div class="field">
+          <label class="label" for="user">Usuário</label>
+          <input class="input" id="user" name="user" placeholder="ex.: admin" autocomplete="username" />
+        </div>
+        <div class="field">
+          <label class="label" for="pass">Senha</label>
+          <input class="input" id="pass" name="pass" type="password" placeholder="••••" autocomplete="current-password" />
+        </div>
+        <button id="btnContinue" class="btn btn-primary" type="submit">Continuar</button>
+      </form>
+    </main>
+  `,
 
   dashboard: () => `
       <div class="app">
@@ -230,6 +253,136 @@ const tpl = {
           </section>
         </main>
       </div>`
+  ,
+
+  dashboardMobile: () => `
+    <div class="app app-mobile">
+      <header class="top panel">
+        <div class="brand-inline">
+          <span class="pill" id="sectionPill">Dashboard</span>
+          <span class="greet" id="greet"></span>
+        </div>
+        <div class="top-actions">
+          <button class="btn btn-outline" id="btnTV" title="Modo TV">TV</button>
+          <button class="logout" id="btnLogout">Sair</button>
+        </div>
+      </header>
+
+      <main class="content panel" id="dashboardContent">
+        <section class="section tickets" id="sectionTickets">
+          <h2>Chamados</h2>
+          <div class="table-wrap" id="ticketsWrap">
+            <table class="table" id="ticketsTable">
+              <thead>
+                <tr>
+                  <th>ID do chamado</th>
+                  <th>Data de criação</th>
+                  <th>Ponto de encontro</th>
+                  <th>Dupla</th>
+                  <th>% de conclusão</th>
+                  <th>% de prazo</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+
+          <div class="ticket-detail" id="ticketDetail" style="display:none; background:#0f131a; border:1px solid var(--card-border); border-radius:12px; padding:12px; margin-top:8px">
+            <header style="display:flex; justify-content:space-between; align-items:center; margin-bottom:6px">
+              <strong id="tdTitle">Chamado</strong>
+              <span class="badge" id="tdPct">0%</span>
+            </header>
+            <div id="tdMeta" style="display:flex; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px"></div>
+            <div class="subtabs" style="display:flex; gap:8px; border-bottom:1px solid var(--card-border); margin-top:10px">
+              <button class="subtab active" data-tab="tdDesc">Descrição</button>
+              <button class="subtab" data-tab="tdNotes">Anotações</button>
+              <button class="subtab" data-tab="tdRDO">RDO's</button>
+              <button class="subtab" data-tab="tdObs">Observações</button>
+              <button class="subtab" data-tab="tdEditForm">Editar</button>
+            </div>
+            <div class="subtab-panel active" id="tdDesc" style="padding-top:10px"></div>
+            <div class="subtab-panel" id="tdNotes" style="display:none;padding-top:10px"><ul id="tdNotesList"></ul></div>
+            <div class="subtab-panel" id="tdRDO" style="display:none;padding-top:10px"><ul id="tdRDOList"></ul></div>
+            <div class="subtab-panel" id="tdObs" style="display:none;padding-top:10px"></div>
+            <div class="subtab-panel" id="tdEditForm" style="display:none;padding-top:10px"></div>
+          </div>
+        </section>
+
+        <section class="section projects" id="sectionProjects">
+          <h2>Projetos</h2>
+          <div class="carousel" id="projectsCarousel"></div>
+          <div class="project-details-inline" id="projectDetailsInline"></div>
+        </section>
+
+        <section class="section" id="sectionCreateTicket" style="display:none">
+          <h2>Novo chamado</h2>
+          <form class="edit-form" id="createTicketForm"></form>
+        </section>
+
+        <section class="section" id="sectionCreateProject" style="display:none">
+          <h2>Novo projeto</h2>
+          <form class="edit-form" id="createProjectForm"></form>
+        </section>
+
+        <section class="section" id="sectionArchivedTickets" style="display:none">
+          <h2>Chamados arquivados</h2>
+          <div class="table-wrap">
+            <table class="table" id="archivedTicketsTable">
+              <thead>
+                <tr>
+                  <th>ID do chamado</th>
+                  <th>Data de criação</th>
+                  <th>Ponto de encontro</th>
+                  <th>Dupla</th>
+                  <th>% de conclusão</th>
+                  <th>% de prazo</th>
+                  <th>Ações</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section" id="sectionFinishedTickets" style="display:none">
+          <h2>Chamados finalizados</h2>
+          <div class="table-wrap"><table class="table" id="finishedTicketsTable"><thead><tr>
+            <th>ID do chamado</th><th>Data de criação</th><th>Ponto de encontro</th><th>Dupla</th><th>% de conclusão</th><th>% de prazo</th><th>Ações</th>
+          </tr></thead><tbody></tbody></table></div>
+        </section>
+
+        <section class="section" id="sectionArchivedProjects" style="display:none">
+          <h2>Projetos arquivados</h2>
+          <div class="table-wrap"><table class="table" id="archivedProjectsTable"><thead><tr>
+            <th>ID</th><th>Nome</th><th>Prazo</th><th>Ações</th>
+          </tr></thead><tbody></tbody></table></div>
+        </section>
+
+        <section class="section" id="sectionFinishedProjects" style="display:none">
+          <h2>Projetos finalizados</h2>
+          <div class="table-wrap"><table class="table" id="finishedProjectsTable"><thead><tr>
+            <th>ID</th><th>Nome</th><th>Prazo</th><th>Ações</th>
+          </tr></thead><tbody></tbody></table></div>
+        </section>
+      </main>
+
+      <nav class="bottom-nav">
+        <button class="bn-btn" data-tab="overview">Visão</button>
+        <button class="bn-btn" data-tab="tickets">Chamados</button>
+        <button class="bn-btn" data-tab="projects">Projetos</button>
+        <button class="bn-btn" data-tab="admin">Admin</button>
+      </nav>
+
+      <div class="admin-subnav" id="adminMenu">
+        <button class="navbtn" id="btnAdminCreateTicket">Criar chamado</button>
+        <button class="navbtn" id="btnAdminArchivedTickets">Chamados arquivados</button>
+        <button class="navbtn" id="btnAdminFinishedTickets">Chamados finalizados</button>
+        <button class="navbtn" id="btnAdminCreateProject">Criar projeto</button>
+        <button class="navbtn" id="btnAdminArchivedProjects">Projetos arquivados</button>
+        <button class="navbtn" id="btnAdminFinishedProjects">Projetos finalizados</button>
+      </div>
+    </div>
+  `
 };
 
 window.tpl = tpl;

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -62,7 +62,7 @@ const tpl = {
             <span class="clock" id="clock" style="margin-left:10px;color:#9aa0a6;font-size:12px"></span>
           </div>
           <div class="top-actions">
-            <button class="tv-mode-btn" id="btnTV" title="Modo TV">📺</button>
+            <button class="btn btn-outline" id="btnTV" title="Modo TV">TV</button>
             <button class="logout" id="btnLogout">Sair</button>
           </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <span class="clock" id="clock" style="margin-left:10px;color:#9aa0a6;font-size:12px"></span>
       </div>
       <div class="top-actions">
-        <button class="tv-mode-btn" id="btnTV" title="Modo TV">📺</button>
+        <button class="btn btn-outline" id="btnTV" title="Modo TV">TV</button>
         <button class="logout" id="btnLogout">Sair</button>
       </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="./assets/css/layout.css">
   <link rel="stylesheet" href="./assets/css/login.css">
   <link rel="stylesheet" href="./assets/css/dashboard.css">
+  <link rel="stylesheet" href="./assets/css/mobile.css">
 </head>
 <body>
   <div class="glow" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- add helpers to manage body classes and hide dashboard sections
- make ticket/project creation views use full panel height
- centralize tab navigation to clear create page state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a8e8681708330bfffa7fe5532eeb3