### PR TITLE
fix: stabilize mobile tabs

### DIFF
--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -158,3 +158,19 @@ body.is-mobile{ padding-bottom:0; }
 /* esconde o logo da sidebar no mobile */
 .is-mobile .sidebar .logo-row{ display:none; }
 .is-mobile .sidebar{ padding-top:56px; }
+
+/* Tickets & Projects pages: stable flex layout without double scroll */
+.is-mobile.tickets-page .content.panel,
+.is-mobile.projects-page .content.panel{
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+}
+
+/* Projects carousel: cards adapt to viewport width */
+.is-mobile #sectionProjects .project{
+  flex:0 0 100%;
+  max-width:100%;
+  scroll-snap-align:start;
+}
+


### PR DESCRIPTION
## Summary
- prevent double scroll on Tickets and Projects pages
- make project carousel cards fill viewport width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d3eae99d4833081192c7bfa49f442