### PR TITLE
feat: add firebase session auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+PORT=80
+NODE_ENV=production
+FIREBASE_PROJECT_ID=seu-projeto
+FIREBASE_WEB_API_KEY=AIza...
+FIREBASE_ADMIN_CLIENT_EMAIL=seu-service-account@seu-projeto.iam.gserviceaccount.com
+FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+COOKIE_NAME=sess
+COOKIE_SECRET=troque-por-um-hex-de-64bytes
+SESSION_TTL_DAYS=7

--- a/assets/js/app/login.js
+++ b/assets/js/app/login.js
@@ -29,11 +29,27 @@
         user.value=''; pass.value=''; enableContinueIfFilled();
       }, 200);
     };
-    const goToDashboard = () => {
+    const goToDashboard = async (data) => {
       viewLogin.style.display = 'none';
       viewDash.style.display = 'block';
+      if(data) await DB.load(data);
       APP.dashboard.init();
     };
+
+    async function bootSession(){
+      try{
+        const me = await fetch('/me', {credentials:'include'});
+        if(me.ok){
+          const db = await fetch('/api/db',{credentials:'include'}).then(r=>r.json());
+          const info = await me.json();
+          window.CURRENT_USER = info.user.email;
+          window.CURRENT_ROLE = db.users?.[window.CURRENT_USER]?.role;
+          await goToDashboard(db);
+        }else{
+          viewLogin.style.display='';
+        }
+      }catch(e){ viewLogin.style.display=''; }
+    }
 
     btnLogin?.addEventListener('click', () => {
       btnCreate.classList.add('fade-out');
@@ -53,19 +69,24 @@
       if (btnContinue.disabled) return;
       const u = user.value.trim();
       const p = pass.value;
-      const res = await fetch('/api/db');
-      const data = await res.json();
-      const account = data.users?.[u];
-      if (account && account.password === p) {
+      const r = await fetch('/auth/login', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        credentials:'include',
+        body: JSON.stringify({ email:u, password:p })
+      });
+      if (r.ok) {
+        const db = await fetch('/api/db',{credentials:'include'}).then(r=>r.json());
         window.CURRENT_USER = u;
-        window.CURRENT_ROLE = account.role;
-        await DB.load(data);
-        goToDashboard();
+        window.CURRENT_ROLE = db.users?.[u]?.role;
+        await goToDashboard(db);
       } else {
         alert('Usuário ou senha inválidos.');
         pass.select();
       }
     });
+
+    bootSession();
   }
 
   APP.login = { bindLogin };

--- a/assets/js/app/ui.js
+++ b/assets/js/app/ui.js
@@ -1105,7 +1105,10 @@
     els.btnTV?.addEventListener('click', APP.tv.toggleTVMode);
 
     // ====== listeners globais (blindados) ======
-    els.btnLogout?.addEventListener('click', ()=>{ location.reload(); });
+    els.btnLogout?.addEventListener('click', async ()=>{
+      await fetch('/auth/logout',{method:'POST',credentials:'include'});
+      location.reload();
+    });
     els.btnHamb?.addEventListener('click', ()=> els.sidebar?.classList.toggle('open'));
     els.sidebar?.addEventListener('click', ev=>{
       if(ev.target === els.sidebar) closeSidebar();

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -33,7 +33,7 @@ const DB = {
     users: {},
   },
   async load(rawData){
-    const data = rawData || await (await fetch('db.json')).json();
+    const data = rawData || await (await fetch('/api/db', {credentials:'include'})).json();
     // tickets e projects vêm como objetos chaveados pelo ID
     this.state.tickets = Object.entries(data.tickets || {}).map(([id, t])=>({id, ...t}));
     this.state.projects = Object.entries(data.projects || {}).map(([id, p])=>({id, ...p}));
@@ -51,7 +51,7 @@ const DB = {
     this.state.tickets.push({id, ...data});
     this.state.historyByTicket[id] = genHistory(data.concl || 0);
     try{
-      await fetch('db.json', {
+      await fetch('/api/db', { credentials:'include',
         method:'PATCH',
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify({tickets:{[id]: data}})

--- a/db.json
+++ b/db.json
@@ -1,11 +1,9 @@
 {
   "users": {
     "admin": {
-      "password": "1234",
       "role": "admin"
     },
     "filipe": {
-      "password": "1234",
       "role": "user"
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,5 +6,14 @@
   "scripts": {
     "start": "node server.js",
     "test": "echo \"No tests specified\""
+  },
+  "type": "module",
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
+    "firebase-admin": "^11.11.0",
+    "helmet": "^7.0.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/readmesecurity.txt
+++ b/readmesecurity.txt
@@ -1,0 +1,57 @@
+# Guia de Autenticação e Segurança
+
+Este projeto utiliza um servidor Node/Express como BFF (Backend for Frontend) para realizar a autenticação no Firebase e entregar os recursos do SPA com cookies HttpOnly.
+
+## Visão geral
+1. O cliente envia `email` e `password` para `POST /auth/login`.
+2. O servidor usa a REST Identity Toolkit do Firebase para obter um `idToken`.
+3. Com o Admin SDK, o servidor converte o `idToken` em **Session Cookie** e salva como cookie HttpOnly.
+4. Todas as rotas protegidas verificam o cookie através do middleware `requireAuth`.
+5. Os assets estáticos públicos são servidos em `/assets` e a SPA em `index.html`. Bundles privados podem ser servidos via `/priv-assets` somente após login.
+
+## Variáveis de ambiente
+Copie `.env.example` para `.env` e preencha:
+
+- `PORT` (padrão 80)
+- `NODE_ENV` (`production` para habilitar cookies `secure`)
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_WEB_API_KEY`
+- `FIREBASE_ADMIN_CLIENT_EMAIL`
+- `FIREBASE_ADMIN_PRIVATE_KEY` (use `\n` para quebras de linha)
+- `COOKIE_NAME` (nome do cookie de sessão)
+- `COOKIE_SECRET` (chave para assinar o cookie)
+- `SESSION_TTL_DAYS` (dias de validade do cookie)
+
+## Configurando o Firebase
+1. Crie um projeto no [Firebase Console](https://console.firebase.google.com/).
+2. Ative o provedor **Email/Password** em *Authentication > Sign-in method*.
+3. Em *Configurações do projeto > Contas de serviço*, gere uma chave JSON e copie o `client_email` e `private_key` para o `.env`.
+4. Em *Configurações do projeto > Geral*, copie a **Web API Key**.
+5. Crie usuários de teste no Firebase Auth com email e senha.
+
+## Estrutura do banco de dados
+- `db.json` armazena dados da aplicação (tickets, projetos etc.).
+- O objeto `users` guarda metadados como `role`. As senhas não são mais salvas aqui; o Firebase gerencia a autenticação.
+- As rotas `/api/db` (GET/PATCH) permitem leitura e escrita do arquivo e requerem sessão válida.
+
+## Endpoints principais
+- `POST /auth/login` – realiza login e cria o cookie de sessão.
+- `POST /auth/logout` – remove o cookie.
+- `GET /me` – retorna o usuário autenticado.
+- `GET /api/db` – lê o banco (requer auth).
+- `PATCH /api/db` – persiste alterações no banco (requer auth).
+- `GET /manifest-priv.json` e `/priv-assets/*` – exemplos de assets privados.
+
+## Como executar
+```bash
+npm install
+npm start
+```
+O servidor iniciará em `http://localhost:80`.
+
+## Boas práticas implementadas
+- Cookies HttpOnly assinados (`SameSite=Lax`).
+- Rate limiting em `/auth/*`.
+- Content Security Policy via Helmet.
+- Assets privados acessíveis apenas após login.
+

--- a/server.js
+++ b/server.js
@@ -1,16 +1,123 @@
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
-const url = require('url');
+import express from "express";
+import helmet from "helmet";
+import rateLimit from "express-rate-limit";
+import cookieParser from "cookie-parser";
+import fetch from "node-fetch";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import admin from "firebase-admin";
 
-const DB_PATH = path.join(__dirname, 'db.json');
-const PUBLIC_DIR = __dirname;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DB_PATH = path.join(__dirname, "db.json");
+
+const {
+  PORT = 80,
+  NODE_ENV,
+  FIREBASE_PROJECT_ID,
+  FIREBASE_WEB_API_KEY,
+  FIREBASE_ADMIN_CLIENT_EMAIL,
+  FIREBASE_ADMIN_PRIVATE_KEY,
+  COOKIE_NAME = "sess",
+  COOKIE_SECRET,
+  SESSION_TTL_DAYS = "7",
+} = process.env;
+
+admin.initializeApp({
+  credential: admin.credential.cert({
+    projectId: FIREBASE_PROJECT_ID,
+    clientEmail: FIREBASE_ADMIN_CLIENT_EMAIL,
+    privateKey: FIREBASE_ADMIN_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+  }),
+});
+
+const app = express();
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        "default-src": ["'self'"],
+        "script-src": ["'self'"],
+        "style-src": ["'self'", "'unsafe-inline'"],
+        "img-src": ["'self'", "data:"],
+        "connect-src": ["'self'"],
+      },
+    },
+  })
+);
+app.disable("x-powered-by");
+
+app.use(express.json({ limit: "100kb" }));
+app.use(cookieParser(COOKIE_SECRET));
+
+const authLimiter = rateLimit({ windowMs: 60_000, max: 10 });
+
+function setSessionCookie(res, sessionCookie) {
+  const maxAgeMs = Number(SESSION_TTL_DAYS) * 24 * 60 * 60 * 1000;
+  res.cookie(COOKIE_NAME, sessionCookie, {
+    httpOnly: true,
+    secure: NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: maxAgeMs,
+    signed: true,
+  });
+}
+function clearSessionCookie(res) {
+  res.clearCookie(COOKIE_NAME);
+}
+
+async function requireAuth(req, res, next) {
+  try {
+    const signed = req.signedCookies[COOKIE_NAME];
+    if (!signed) return res.status(401).json({ error: "unauthorized" });
+    const decoded = await admin.auth().verifySessionCookie(signed, true);
+    req.user = { uid: decoded.uid, email: decoded.email };
+    next();
+  } catch {
+    return res.status(401).json({ error: "unauthorized" });
+  }
+}
+
+app.post("/auth/login", authLimiter, async (req, res) => {
+  const { email, password } = req.body || {};
+  if (!email || !password) return res.status(400).json({ error: "missing_credentials" });
+
+  const resp = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${FIREBASE_WEB_API_KEY}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, returnSecureToken: true }),
+    }
+  );
+  if (!resp.ok) return res.status(401).json({ error: "invalid_credentials" });
+  const { idToken } = await resp.json();
+
+  const expiresIn = Number(SESSION_TTL_DAYS) * 24 * 60 * 60 * 1000;
+  const sessionCookie = await admin
+    .auth()
+    .createSessionCookie(idToken, { expiresIn });
+  setSessionCookie(res, sessionCookie);
+  return res.json({ ok: true });
+});
+
+app.post("/auth/logout", requireAuth, (req, res) => {
+  clearSessionCookie(res);
+  return res.json({ ok: true });
+});
+
+app.get("/me", requireAuth, (req, res) => {
+  res.json({ ok: true, user: req.user });
+});
 
 function deepMerge(target, source) {
-  if (typeof source !== 'object' || source === null) return target;
+  if (typeof source !== "object" || source === null) return target;
   for (const key of Object.keys(source)) {
     const srcVal = source[key];
-    if (srcVal && typeof srcVal === 'object' && !Array.isArray(srcVal)) {
+    if (srcVal && typeof srcVal === "object" && !Array.isArray(srcVal)) {
       target[key] = deepMerge(target[key] || {}, srcVal);
     } else {
       target[key] = srcVal;
@@ -19,80 +126,59 @@ function deepMerge(target, source) {
   return target;
 }
 
-const server = http.createServer((req, res) => {
-  const parsed = url.parse(req.url, true);
-
-  // API endpoints
-  if (req.method === 'GET' && parsed.pathname === '/api/db') {
-    fs.readFile(DB_PATH, 'utf8', (err, data) => {
-      if (err) {
-        res.statusCode = 500;
-        return res.end(JSON.stringify({ error: 'Failed to read db' }));
-      }
-      res.setHeader('Content-Type', 'application/json');
-      res.end(data);
-    });
-    return;
-  }
-
-  if (req.method === 'PATCH' && parsed.pathname === '/api/db') {
-    let body = '';
-    req.on('data', chunk => (body += chunk));
-    req.on('end', () => {
-      try {
-        const patch = JSON.parse(body || '{}');
-        fs.readFile(DB_PATH, 'utf8', (err, data) => {
-          if (err) {
-            res.statusCode = 500;
-            return res.end(JSON.stringify({ error: 'Failed to read db' }));
-          }
-          let json = {};
-          try { json = JSON.parse(data); } catch {}
-          deepMerge(json, patch);
-          fs.writeFile(DB_PATH, JSON.stringify(json, null, 2), 'utf8', err2 => {
-            if (err2) {
-              res.statusCode = 500;
-              return res.end(JSON.stringify({ error: 'Failed to write db' }));
-            }
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify({ status: 'ok' }));
-          });
-        });
-      } catch (e) {
-        res.statusCode = 400;
-        res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      }
-    });
-    return;
-  }
-
-  // Static files
-  if (req.method === 'GET') {
-    let filePath = path.join(PUBLIC_DIR, parsed.pathname === '/' ? 'index.html' : parsed.pathname);
-    fs.readFile(filePath, (err, data) => {
-      if (err) {
-        res.statusCode = 404;
-        return res.end('Not found');
-      }
-      const ext = path.extname(filePath).toLowerCase();
-      const map = {
-        '.html': 'text/html',
-        '.js': 'application/javascript',
-        '.css': 'text/css',
-        '.json': 'application/json'
-      };
-      res.setHeader('Content-Type', map[ext] || 'text/plain');
-      res.end(data);
-    });
-    return;
-  }
-
-  res.statusCode = 404;
-  res.end('Not found');
+app.get("/api/db", requireAuth, (req, res) => {
+  fs.readFile(DB_PATH, "utf8", (err, data) => {
+    if (err) return res.status(500).json({ error: "Failed to read db" });
+    res.setHeader("Content-Type", "application/json");
+    res.send(data);
+  });
 });
 
-const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+app.patch("/api/db", requireAuth, (req, res) => {
+  const patch = req.body || {};
+  fs.readFile(DB_PATH, "utf8", (err, data) => {
+    if (err) return res.status(500).json({ error: "Failed to read db" });
+    let json = {};
+    try {
+      json = JSON.parse(data);
+    } catch {}
+    deepMerge(json, patch);
+    fs.writeFile(DB_PATH, JSON.stringify(json, null, 2), "utf8", (err2) => {
+      if (err2) return res.status(500).json({ error: "Failed to write db" });
+      res.json({ status: "ok" });
+    });
+  });
 });
 
+app.use(
+  "/assets",
+  express.static(path.join(__dirname, "assets"), {
+    setHeaders: (res, filePath) => {
+      if (filePath.endsWith(".js") || filePath.endsWith(".css")) {
+        res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+      }
+    },
+  })
+);
+
+app.use(
+  "/priv-assets",
+  requireAuth,
+  express.static(path.join(__dirname, "dist_priv"), {
+    setHeaders: (res) => {
+      res.setHeader("Cache-Control", "private, max-age=3600");
+    },
+  })
+);
+
+app.get("/manifest-priv.json", requireAuth, (req, res) => {
+  res.json({});
+});
+
+app.get("*", (req, res) => {
+  res.sendFile(path.join(__dirname, "index.html"));
+});
+
+app.listen(PORT, () => {
+  console.log(`Listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- replace Node HTTP server with Express backend using Firebase session cookies
- update frontend login/logout to call new auth endpoints and protect DB access
- document authentication flow and required env vars

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `node server.js` *(fails: Cannot find package 'express')*


------
https://chatgpt.com/codex/tasks/task_b_689dfe44cca08330933d29fd5e01e482